### PR TITLE
vendor: Update and fix apns-conf for better IMS support

### DIFF
--- a/prebuilt/common/etc/apns-conf.xml
+++ b/prebuilt/common/etc/apns-conf.xml
@@ -2,6 +2,7 @@
 <!--
 /*
 ** Copyright 2006, Google Inc.
+** Copyright 2020, The Potato Open Sauce Project
 **
 ** Licensed under the Apache License, Version 2.0 (the "License");
 ** you may not use this file except in compliance with the License.
@@ -176,7 +177,6 @@
   <apn carrier="NRJ WEB" mcc="208" mnc="10" apn="fnetnrj" proxy="" port="" user="" password="" mmsc="" spn="NRJ (SFR)" type="default,supl" />
   <apn carrier="NRJ Mobile FR Internet" mcc="208" mnc="10" apn="internetnrj" proxy="" port="" user="" password="" mmsc="" type="dun" />
   <apn carrier="SFR Internet Mobile" mcc="208" mnc="10" apn="sl2sfr" user="" password="" spn="F SFR" type="default,supl" />
-  <apn carrier="SFR IMS" mcc="208" mnc="10" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
   <apn carrier="SFR MMS" mcc="208" mnc="10" apn="mmssfr" proxy="" port="" mmsproxy="10.151.0.1" mmsport="8080" mmsc="http://mms1" user="" password="" spn="F SFR" type="mms" />
   <apn carrier="SFR WEB" mcc="208" mnc="10" apn="websfr" user="" password="" spn="F SFR" type="default,dun" />
   <apn carrier="SFR WAP" mcc="208" mnc="10" apn="wapsfr" proxy="195.115.25.129" port="8080" user="none" password="none" server="*" mmsc="" type="default,supl" />
@@ -221,14 +221,6 @@
   <apn carrier="Iliad Int" mcc="208" mnc="15" apn="iliad" mmsc="http://mms.iliad-italia.it" type="default,supl,mms" mvno_match_data="F003" mvno_type="gid" />
   <apn carrier="Legos" mcc="208" mnc="17" apn="bornsip" type="default,supl" />
   <apn carrier="Legos MMS" mcc="208" mnc="17" apn="bornsipmms" mmsc="http://mms.bornsip.fr:8191" type="mms" />
-  <apn carrier="Bouygues Telecom" mcc="208" mnc="20" apn="mmsbouygtel.com" proxy="" port="" user="" password="" mmsc="http://mms.bouyguestelecom.fr/mms/wapenc" mmsproxy="62.201.129.226" mmsport="8080" mvno_type="spn" mvno_match_data="Bouygues Telecom" type="default,supl,mms" />
-  <apn carrier="Bouygues Pro" mcc="208" mnc="20" apn="a2bouygtel.com" user="a2b" password="acces" type="default,supl" />
-  <apn carrier="Bouygues WAP" mcc="208" mnc="20" apn="mmsbouygtel.com" type="default,supl" />
-  <apn carrier="Bouygues MMS" mcc="208" mnc="20" apn="mmsbouygtel.com" proxy="" port="" user="" password="" mmsc="http://mms.bouyguestelecom.fr/mms/wapenc" mmsproxy="62.201.129.226" mmsport="8080" mvno_type="spn" mvno_match_data="Bouygues Telecom" type="default,supl,mms" />
-  <apn carrier="Web" mcc="208" mnc="20" apn="mmsbouygtel.com" proxy="" port="" user="" password="" mmsc="http://wap.bouygtel.fr/" type="default,supl" />
-  <apn carrier="Lebara internet" mcc="208" mnc="20" apn="fr.lebara.mobi" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="Lebara" type="default,supl" />
-  <apn carrier="Numericable 3G" mcc="208" mnc="20" apn="numericable.fr" proxy="" port="" user="" password="" mmsc="http://m.numericable.fr" mvno_type="spn" mvno_match_data="Numericable" type="default,supl" />
-  <apn carrier="Simyo Web" mcc="208" mnc="20" apn="gprs-service-fr.net" proxy="195.230.105.25" port="8080" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="Simyo" authtype="3" type="default,supl" />
   <apn carrier="BouyguesGPRS ISP" mcc="208" mnc="21" apn="ebouygtel.com" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="MMS Bouygues" mcc="208" mnc="21" apn="mmsbouygtel.com" proxy="" port="" user="" password="" mmsc="http://mms.bouyguestelecom.fr/mms/wapenc" mmsproxy="62.201.129.226" mmsport="8080" type="mms" />
   <apn carrier="Virgin FR" mcc="208" mnc="23" apn="virgin-mobile.fr" mmsc="http://virginmms.fr" mmsproxy="10.6.10.1" mmsport="8080" type="default,mms" />
@@ -323,9 +315,6 @@
   <apn carrier="T-Mobile MMS" mcc="216" mnc="30" apn="mms" proxy="" port="" mmsproxy="212.051.126.010" mmsport="8080" mmsc="http://mms.t-mobile.hu/servlets/mms" user="mms" password="mms" authtype="1" type="mms" />
   <apn carrier="Telekom HU NET" mcc="216" mnc="30" apn="internet.telekom" type="default,supl" />
   <apn carrier="Telekom HU MMS" mcc="216" mnc="30" apn="internet.telekom" mmsc="http://mms.t-mobile.hu/servlets/mms" mmsproxy="212.51.126.10" mmsport="8080" type="mms" />
-  <apn carrier="Vodafone HU" mcc="216" mnc="70" apn="internet.vodafone.net" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="VF Internet VitaMax" mcc="216" mnc="70" apn="vitamax.internet.vodafone.net" user="" password="" type="default,supl" />
-  <apn carrier="Vodafone HU MMS" mcc="216" mnc="70" apn="mms.vodafone.net" proxy="" port="" user="" password="" mmsc="http://mms.vodafone.hu/servlets/mms" mmsproxy="80.244.97.2" mmsport="8080" type="mms" />
   <apn carrier="ERONET START" mcc="218" mnc="03" apn="gprs.eronet.ba" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="ERONET MI 50" mcc="218" mnc="03" apn="web.eronet.ba" proxy="" port="" user="" password="" mmsc="" type="supl" />
   <apn carrier="ERONET MI 200" mcc="218" mnc="03" apn="web.eronet.ba" proxy="" port="" user="" password="" mmsc="" type="supl" />
@@ -375,9 +364,6 @@
   <apn carrier="COOPVOCE WEB" mcc="222" mnc="01" apn="web.coopvoce.it" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="Coop Mobile" type="default,supl" />
   <apn carrier="COOPVOCE MMS" mcc="222" mnc="01" apn="mms.coopvoce.it" proxy="" port="" user="" password="" mmsc="http://mms.coop.it/servlets/mms" mmsproxy="213.230.130.89" mmsport="80" mvno_type="spn" mvno_match_data="Coop Mobile" authtype="1" type="mms" />
   <apn carrier="Fastweb 4G" mcc="222" mnc="08" apn="apn.fastweb.it" proxy="" port="" user="" password="" mmsc="http://mms.fastweb.it/mms/wapenc" mmsproxy="85.18.189.217" mmsport="8080" mvno_type="spn" mvno_match_data="FASTWEB" authtype="2" type="default,supl,mms" />
-  <apn carrier="Iusacell Internet" mcc="222" mnc="010" apn="web.iusacellgsm.mx" user="iusacellgsm" password="iusacellgsm" authtype="0" type="default,supl" />
-  <apn carrier="Internet Modem" mcc="222" mnc="010" apn="modem.iusacellgsm.mx" user="iusacellgsm" password="iusacellgsm" type="dun" />
-  <apn carrier="Iusacell MMS" mcc="222" mnc="010" apn="mms.iusacellgsm.mx" mmsc="http://mms.iusacell3g.com/" user="mmsiusacellgsm" password="mmsiusacellgsm" type="mms" />
   <apn carrier="Iusacell Internet" mcc="222" mnc="011" apn="web.iusacellgsm.mx" user="iusacellgsm" password="iusacellgsm" authtype="0" type="default,supl" />
   <apn carrier="Internet Modem" mcc="222" mnc="011" apn="modem.iusacellgsm.mx" user="iusacellgsm" password="iusacellgsm" type="dun" />
   <apn carrier="Iusacell MMS" mcc="222" mnc="011" apn="mms.iusacellgsm.mx" mmsc="http://mms.iusacell3g.com/" user="mmsiusacellgsm" password="mmsiusacellgsm" type="mms" />
@@ -405,15 +391,6 @@
   <apn carrier="Iusacell Internet" mcc="222" mnc="019" apn="web.iusacellgsm.mx" user="iusacellgsm" password="iusacellgsm" authtype="0" type="default,supl" />
   <apn carrier="Internet Modem" mcc="222" mnc="019" apn="modem.iusacellgsm.mx" user="iusacellgsm" password="iusacellgsm" type="dun" />
   <apn carrier="Iusacell MMS" mcc="222" mnc="019" apn="mms.iusacellgsm.mx" mmsc="http://mms.iusacell3g.com/" user="mmsiusacellgsm" password="mmsiusacellgsm" type="mms" />
-  <apn carrier="Vodafone Tethering" mcc="222" mnc="10" apn="web.omnitel.it" type="dun" />
-  <apn carrier="Vodafone IT" mcc="222" mnc="10" apn="mobile.vodafone.it" type="default,supl" />
-  <apn carrier="Vodafone IT MMS" mcc="222" mnc="10" apn="mms.vodafone.it" mmsproxy="10.128.224.10" mmsport="80" mmsc="http://mms.vodafone.it/servlets/mms" type="mms" />
-  <apn carrier="Vodafone IT IMS" mcc="222" mnc="10" apn="ims" type="ims" protocol="IPV4V6" />
-  <apn carrier="Internet da cellulare" mcc="222" mnc="10" apn="wap.omnitel.it" proxy="10.128.201.76" port="80" type="default,supl" />
-  <apn carrier="PosteMobile" mcc="222" mnc="10" apn="internet.postemobile.it" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="PosteMobile" type="default,supl" />
-  <apn carrier="PosteMobile WAP" mcc="222" mnc="10" apn="wap.postemobile.it" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="PosteMobile" spn="Post mobile" type="default,supl" />
-  <apn carrier="PosteMobile MMS" mcc="222" mnc="10" apn="mms.postemobile.it" proxy="" port="" user="" password="" mmsc="http://mms.postemobile.it/servlets/mms" mmsproxy="10.128.224.10" mmsport="80" mvno_type="spn" mvno_match_data="PosteMobile" spn="Post mobile" type="mms" />
-  <apn carrier="Lycamobile" mcc="222" mnc="10" apn="data.lycamobile.it" user="lmit" password="plus" type="default,supl" />
   <apn carrier="Iusacell Internet" mcc="222" mnc="11" apn="web.iusacellgsm.mx" user="iusacellgsm" password="iusacellgsm" authtype="0" type="default,supl" />
   <apn carrier="Iusacell Modem" mcc="222" mnc="11" apn="modem.iusacellgsm.mx" user="iusacellgsm" password="iusacellgsm" type="dun" />
   <apn carrier="Iusacell MMS" mcc="222" mnc="11" apn="mms.iusacellgsm.mx" mmsc="http://mms.iusacell3g.com/" user="mmsiusacellgsm" password="mmsiusacellgsm" type="mms" />
@@ -450,21 +427,14 @@
   <apn carrier="Fastweb 3G" mcc="222" mnc="99" apn="apn.fastweb.it" proxy="" port="" user="" password="" mmsc="http://mms.fastweb.it/mms/wapenc" mmsproxy="10.0.65.9" mmsport="8080" mvno_type="spn" mvno_match_data="FASTWEB" authtype="2" type="default,supl,mms" />
   <apn carrier="Connect Mobile" mcc="226" mnc="03" apn="broadband" type="default,supl" protocol="IP" roaming_protocol="IP" />
   <apn carrier="Connect Mobile" mcc="226" mnc="06" apn="broadband" type="default,supl" protocol="IP" roaming_protocol="IP" />
-  <apn carrier="Digi.Mobil" mcc="226" mnc="05" apn="internet" type="default,supl" />
   <apn carrier="IMS" mcc="226" mnc="03" apn="ims" type="ims" protocol="IP" roaming_protocol="IP" />
-  <apn carrier="IMS" mcc="226" mnc="05" apn="ims" type="ims" protocol="IP" roaming_protocol="IPV4V6" />
   <apn carrier="IMS" mcc="226" mnc="06" apn="ims" type="ims" protocol="IP" roaming_protocol="IP" />
-  <apn carrier="Internet" mcc="226" mnc="01" apn="internet.vodafone.ro" protocol="IP" roaming_protocol="IP"/>
-  <apn carrier="MMS" mcc="226" mnc="05" apn="mms" mmsc="http://10.10.3.133:8002" mmsport="8080" mmsproxy="10.10.3.130" type="mms" />
   <apn carrier="Orange Internet" mcc="226" mnc="10" apn="net" type="default" />
-  <apn carrier="Orange MMS" mcc="226" mnc="10" apn="mms" user="mms"  mmsc="http://wap.mms.orange.ro:8002" mmsport="8799" authtype="1" type="mms" />
+  <apn carrier="Orange MMS" mcc="226" mnc="10" apn="mms" user="mms" mmsc="http://wap.mms.orange.ro:8002" mmsport="8799" authtype="1" type="mms" />
   <apn carrier="Orange Voce" mcc="226" mnc="10" apn="ims" type="ims" authtype="0" protocol="IPV6" />
   <apn carrier="RO - Cosmote (WnW) Web" mcc="226" mnc="04" apn="wnw" type="default,supl" authtype="1" user="wnw" password="wnw" />
   <apn carrier="Telekom MMS" mcc="226" mnc="03" apn="mms" mmsc="http://mmsc1.mms.telekom.ro:8002" mmsport="8080" mmsproxy="10.252.1.62" password="mms" type="mms" user="mms" authtype="1" protocol="IP" roaming_protocol="IP" />
   <apn carrier="Telekom MMS" mcc="226" mnc="06" apn="mms" mmsc="http://mmsc1.mms.telekom.ro:8002" mmsport="8080" mmsproxy="10.252.1.62" password="mms" type="mms" user="mms" authtype="1" protocol="IP" roaming_protocol="IP" />
-  <apn carrier="Vodafone Internet" mcc="226" mnc="01" apn="internet.vodafone.ro" proxy="" port="" user="internet.vodafone.ro" password="vodafone" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone MMS" mcc="226" mnc="01" apn="mms.vodafone.ro" mmsc="http://multimedia/servlets/mms" mmsport="8080" mmsproxy="193.230.161.231" password="vodafone" type="mms" user="mms" protocol="IP" roaming_protocol="IP" />
-  <apn carrier="Vodafone RO" mcc="226" mnc="01" apn="internet.vodafone.ro" proxy="" port="" user="internet.vodafone.ro" password="vodafone" mmsc="" type="default,supl" />
   <apn carrier="Vodafone live!" mcc="226" apn="live.vodafone.com" type="default,supl,dun" roaming_protocol="IP" />
   <apn carrier="web'n'walk" mcc="226" mnc="03" apn="wnw" type="default,supl" user="wnw" password="wnw" authtype="3" protocol="IP" roaming_protocol="IP" />
   <apn carrier="web'n'walk" mcc="226" mnc="06" apn="wnw" type="default,supl" user="wnw" password="wnw" authtype="3" protocol="IP" roaming_protocol="IP" />
@@ -566,40 +536,6 @@
   <apn carrier="O2 WAP(post)" mcc="234" mnc="11" apn="wap.o2.co.uk" proxy="193.113.200.195" port="8080" user="payandgo" password="password" type="default,supl" />
   <apn carrier="O2 MMS(pre)" mcc="234" mnc="11" apn="payandgo.o2.co.uk" mmsproxy="193.113.200.195" mmsport="8080" mmsc="http://mmsc.mms.o2.co.uk:8002" user="payandgo" password="password" type="mms" />
   <apn carrier="O2 MMS(post)" mcc="234" mnc="11" apn="wap.o2.co.uk" proxy="193.113.200.195" port="8080" mmsc="http://mmsc.mms.o2.co.uk:8002" user="o2wap" password="password" type="mms" />
-  <apn carrier="Vodafone Internet(Pre)" mcc="234" mnc="15" apn="pp.vodafone.co.uk" proxy="" port="" user="web" password="web" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone Internet(Post)" mcc="234" mnc="15" apn="internet" proxy="" port="" user="web" password="web" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone WAP(Pre)" mcc="234" mnc="15" apn="pp.vodafone.co.uk" proxy="212.183.137.12" port="8799" user="wap" password="wap" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone WAP(Post)" mcc="234" mnc="15" apn="wap.vodafone.co.uk" proxy="212.183.137.12" port="8799" user="wap" password="wap" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone MMS(Pre)" mcc="234" mnc="15" apn="pp.vodafone.co.uk" proxy="" port="" user="wap" password="wap" mmsc="http://mms.vodafone.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" type="mms" />
-  <apn carrier="Vodafone MMS(Post)" mcc="234" mnc="15" apn="wap.vodafone.co.uk" proxy="" port="" user="wap" password="wap" mmsc="http://mms.vodafone.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" type="mms" />
-  <apn carrier="Vodafone UK Contract Internet" mcc="234" mnc="15" apn="Internet" user="web" password="web" server="*" mmsc="http://mms.vodafone.co.uk/servlets/mms" mmsproxy="212.183.137.012" mmsport="8799" type="default,supl,mms" />
-  <apn carrier="Vodafone Post-pay ISP" mcc="234" mnc="15" apn="internet" user="web" password="web" type="default,supl" />
-  <apn carrier="Talkmobile" mcc="234" mnc="15" apn="payg.talkmobile.co.uk" type="default,supl" />
-  <apn carrier="Talkmobile MMS" mcc="234" mnc="15" apn="payg.talkmobile.co.uk" user="wap" password="password" mmsc="http://mms.talkmobile.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" type="mms" />
-  <apn carrier="Vodafone Prepay" mcc="234" mnc="15" apn="pp.vodafone.co.uk" user="wap" password="wap" mmsc="http://mms.vodafone.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" type="default,supl,mms" />
-  <apn carrier="Vodafone UK Contract WAP" mcc="234" mnc="15" apn="wap.vodafone.co.uk" user="wap" password="wap" server="*" mmsc="http://mms.vodafone.co.uk/servlets/mms" mmsproxy="212.183.137.012" mmsport="8799" type="default,supl,mms" />
-  <apn carrier="Lebara UK" mcc="234" mnc="15" apn="uk.lebara.mobi" user="web" password="web" type="default,supl" />
-  <apn carrier="Lebara UK MMS" mcc="234" mnc="15" apn="uk.lebara.mobi" user="web" password="web" server="*" mmsc="http://mms.lebara.co.uk/servlets/mms" mmsproxy="212.183.137.012" mmsport="8799" type="mms" />
-  <apn carrier="Talkmobile" mcc="234" mnc="15" apn="talkmobile.co.uk" user="wap" password="wap" mmsc="http://mms.talkmobile.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" type="default,supl,mms" />
-  <apn carrier="OVIVO" mcc="234" mnc="15" apn="ovivomobile.com" type="default,supl" />
-  <apn carrier="OVIVO MMS" mcc="234" mnc="15" apn="gprsconnect.com" mmsc="http://mms.gprsconnect.com/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" type="mms" />
-  <apn carrier="TalkTalk" mcc="234" mnc="15" apn="mobile.talktalk.co.uk" mmsc="http://mms.talktalk.co.uk/servlets/mms" port="8799" mmsproxy="212.183.137.12" mmsport="8799" authtype="1" type="default" />
-  <apn carrier="Sainsburys" mcc="234" mnc="15" apn="payg.mobilebysainsburys.co.uk" proxy="" port="" user="" password="" mmsc="http://mms.mobilesainsburys.co.uk/servltes/mms" mmsproxy="212.183.137.12" mmsport="8799" authtype="1" type="default,supl,mms" />
-  <apn carrier="Sainsbury's Internet" mcc="234" mnc="15" apn="payg.mobilebysainsburys.co.uk" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="Sainsbury's" type="default,supl" />
-  <apn carrier="UK - Lebara Web" mcc="234" mnc="15" apn="uk.lebara.mobi" proxy="" port="" user="web" password="web" mmsc="" mvno_type="spn" mvno_match_data="Lebara" authtype="1" type="default,supl" />
-  <apn carrier="UK - Lebara MMS" mcc="234" mnc="15" apn="" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="Lebara" authtype="1" type="mms" />
-  <apn carrier="UK - Lebara GPRS" mcc="234" mnc="15" apn="uk.lebara.mobi" proxy="" port="" user="wap" password="wap" mmsc="http://mms.lebara.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" mvno_type="spn" mvno_match_data="Lebara" authtype="1" type="default,supl,mms,wap" />
-  <apn carrier="Sainsbury's MMS" mcc="234" mnc="15" apn="Sainsburys MMS" proxy="" port="" user="" password="" mmsc="http://mms.mobilebysainsburys.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" mvno_type="spn" mvno_match_data="Sainsbury's" type="mms" />
-  <apn carrier="Talkmobile Payg" mcc="234" mnc="15" apn="payg.talkmobile.co.uk" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="Talkmobile" type="default,supl" />
-  <apn carrier="Talkmobile MMS Payg" mcc="234" mnc="15" apn="payg.talkmobile.co.uk" proxy="" port="" user="wap" password="password" mmsc="http://mms.talkmobile.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" mvno_type="spn" mvno_match_data="Talkmobile" type="mms" />
-  <apn carrier="Talkmobile" mcc="234" mnc="15" apn="talkmobile.co.uk" proxy="" port="" user="wap" password="wap" mmsc="http://mms.talkmobile.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" mvno_type="spn" mvno_match_data="Talkmobile" type="default,supl,mms" />
-  <apn carrier="Contract WAP" mcc="234" mnc="15" apn="wap.vodafone.co.uk" proxy="" port="" user="wap" password="wap" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="Contract WAP MMS" mcc="234" mnc="15" apn="wap.vodafone.co.uk" proxy="" port="" user="wap" password="wap" mmsc="http://mms.vodafone.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" authtype="1" type="mms" />
-  <apn carrier="Vodafone Pre Pay" mcc="234" mnc="15" apn="pp.vodafone.co.uk" proxy="" port="" user="wap" password="wap" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone Pre Pay MMS" mcc="234" mnc="15" apn="pp.vodafone.co.uk" proxy="" port="" user="wap" password="wap" mmsc="http://mms.vodafone.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" type="mms" />
-  <apn carrier="OVIVO" mcc="234" mnc="15" apn="ovivomobile.com" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="Ovivo" type="default,supl,dun,fota" />
-  <apn carrier="BT Mobile" mcc="234" mnc="15" apn="btmobile.bt.com" proxy="" port="" user="bt" password="bt" mmsc="" mvno_type="spn" mvno_match_data="BT" authtype="1" type="default,supl" />
-  <apn carrier="BT Mobile" mcc="234" mnc="15" apn="btmobile.bt.com" proxy="" port="" user="bt" password="bt" mmsc="http://mms.bt.com/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" mvno_type="spn" mvno_match_data="BT" authtype="1" type="mms" />
   <apn carrier="3 Internet" mcc="234" mnc="20" apn="three.co.uk" type="default,supl" />
   <apn carrier="3 Modem" mcc="234" mnc="20" apn="3internet" type="default,supl" />
   <apn carrier="3 MMS" mcc="234" mnc="20" apn="three.co.uk" proxy="" port="" user="" password="" mmsc="http://mms.um.three.co.uk:10021/mmsc" mmsproxy="217.171.129.2" mmsport="8799" type="mms" />
@@ -804,12 +740,6 @@
   <apn carrier="Glocalnet Internet" mcc="240" mnc="06" apn="internet.glocalnet.se" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="Glocalnet MMS" mcc="240" mnc="06" apn="services.glocalnet.se" proxy="" port="" user="" password="" mmsc="http://mms" mmsproxy="172.30.253.241" mmsport="8799" type="mms" />
   <apn carrier="Glocalnet WAP GPRS" mcc="240" mnc="06" apn="services.glocalnet.se" proxy="172.30.253.241" port="8799" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Tele2 Internet" mcc="240" mnc="07" apn="4g.tele2.se" type="default,supl" />
-  <apn carrier="Tele2 MMS" mcc="240" mnc="07" apn="4g.tele2.se" mmsc="http://mmsc.tele2.se" mmsproxy="130.244.202.30" mmsport="8080" type="mms" />
-  <apn carrier="Tele2 Internet" mcc="240" mnc="07" apn="internet.tele2.no" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Tele2 MMS" mcc="240" mnc="07" apn="internet.tele2.no" proxy="" port="" user="" password="" mmsc="http://mmsc.tele2.no" mmsproxy="193.12.40.14" mmsport="8080" type="mms" />
-  <apn carrier="Spring data" mcc="240" mnc="07" apn="data.springmobil.se" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Spring MMS" mcc="240" mnc="07" apn="mms.springmobil.se" proxy="" port="" user="" password="" mmsc="http://mms.springmobil.se" mmsproxy="213.88.184.37" mmsport="8080" type="mms" />
   <apn carrier="Glocalnet Mobilsurf" mcc="240" mnc="08" apn="services.glocalnet.se" proxy="172.30.253.241" port="8799" mmsc="" user="" password="" authtype="3" type="default,supl" spn="Glocalnet" />
   <apn carrier="Glocalnet MMS" mcc="240" mnc="08" apn="services.glocalnet.se" proxy="" port="" mmsproxy="172.30.253.241" mmsport="8799" mmsc="http://mms" user="" password="" authtype="3" type="mms" spn="Glocalnet" />
   <apn carrier="Telenor Mobilsurf" mcc="240" mnc="08" apn="services.telenor.se" proxy="172.30.253.241" port="8799" mmsc="" user="" password="" authtype="3" type="default,supl" />
@@ -938,53 +868,14 @@
   <apn carrier="Tele2 EE" mcc="248" mnc="03" apn="internet.tele2.ee" proxy="" port="" user="wap" password="wap" mmsc="" type="default,supl" />
   <apn carrier="Tele2 EE MMS" mcc="248" mnc="03" apn="mms.emt.ee" proxy="" port="" user="" password="" mmsc="http://mms.emt.ee/servlets/mms" mmsproxy="217.71.32.82" mmsport="8080" type="mms" />
   <apn carrier="Tele2 MMS" mcc="248" mnc="03" apn="mms.tele2.ee" proxy="" port="" user="" password="" mmsc="http://mmsc.tele2.ee" mmsproxy="193.12.40.6" mmsport="8080" type="mms" />
-  <apn carrier="MTS RU" mcc="250" mnc="01" apn="internet.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="ETK" mcc="250" mnc="01" apn="mms.etk.ru" proxy="" port="" user="mms" password="mms" mmsc="http://mmsc" mmsproxy="10.10.30.60" mmsport="8080" type="default,supl,mms" />
-  <apn carrier="MTS RU MMS" mcc="250" mnc="01" apn="mms.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="http://mmsc" mmsproxy="192.168.192.192" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="Megafon Internet" mcc="250" mnc="02" apn="internet" proxy="" port="" user="" password="" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="Megafon MMS" mcc="250" mnc="02" apn="mms" proxy="" port="" user="mms" password="mms" mmsc="http://mmsc:8002" mmsproxy="10.10.10.10" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="NCC" mcc="250" mnc="03" apn="mms" proxy="" port="" user="" password="" mmsc="http://10.0.3.50" mmsproxy="10.0.3.20" mmsport="8080" type="mms" />
-  <apn carrier="МТС-интернет" mcc="250" mnc="04" apn="internet.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="МТС Центр MMS" mcc="250" mnc="04" apn="mms.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="http://mmsc" mmsproxy="192.168.192.192" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="ETK" mcc="250" mnc="05" apn="internet.etk.ru" proxy="" port="" user="" password="" mmsc="" type="default,supl,mms" />
-  <apn carrier="МТС-интернет" mcc="250" mnc="05" apn="internet.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="МТС Центр MMS" mcc="250" mnc="05" apn="mms.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="http://mmsc" mmsproxy="192.168.192.192" mmsport="8080" authtype="1" type="mms" />
   <apn carrier="Smarts RU internet" mcc="250" mnc="07" apn="internet.smarts.ru" type="default,supl" />
   <apn carrier="Smarts RU mms" mcc="250" mnc="07" apn="mms.smarts.ru" user="n@k" password="nok" mmsc="http://mmsc:8002" mmsproxy="172.24.121.5" mmsport="8080" type="mms" />
   <apn carrier="internet" mcc="250" mnc="07" apn="internet.smarts.ru" proxy="" port="" user="any" password="any" mmsc="" type="default,supl" />
   <apn carrier="mms" mcc="250" mnc="07" apn="mms.smarts.ru" proxy="" port="" user="wap" password="wap" mmsc="http://172.24.120.135/mms/wapenc" mmsproxy="172.24.128.5" mmsport="8080" type="mms" />
-  <apn carrier="МТС-интернет" mcc="250" mnc="10" apn="internet.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="МТС Центр MMS" mcc="250" mnc="10" apn="mms.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="http://mmsc" mmsproxy="192.168.192.192" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="Beeline internet" mcc="250" mnc="11" apn="internet.beeline.ru" proxy="" port="" user="beeline" password="beeline" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="Beeline MMS" mcc="250" mnc="11" apn="mms.beeline.ru" proxy="" port="" user="beeline" password="beeline" mmsc="http://mms/" mmsproxy="192.168.94.23" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="Yota" mcc="250" mnc="11" apn="internet.yota" authtype="1" type="default,supl" />
-  <apn carrier="Yota MMS" mcc="250" mnc="11" apn="mms.yota" mmsc="http://mmsc:8002" mmsproxy="10.10.10.10" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="GPRS-Internet" mcc="250" mnc="12" apn="inet.bwc.ru" proxy="" port="" user="bwc" password="bwc" mmsc="" type="default,supl" />
-  <apn carrier="BWC MMS" mcc="250" mnc="12" apn="mms.bwc.ru" proxy="" port="" user="bwc" password="bwc" mmsc="http://mmsc/mms" mmsproxy="10.10.17.2" mmsport="8080" type="mms" />
-  <apn carrier="МТС-интернет" mcc="250" mnc="13" apn="internet.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="МТС Центр MMS" mcc="250" mnc="13" apn="mms.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="http://mmsc" mmsproxy="192.168.192.192" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="MMS" mcc="250" mnc="16" apn="mms.ntc" proxy="" port="" user="" password="" mmsc="http://mmsc.vntc.ru/was" mmsproxy="80.243.64.68" mmsport="8080" type="mms" />
-  <apn carrier="Internet" mcc="250" mnc="17" apn="internet.usi.ru" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="MMS" mcc="250" mnc="17" apn="mms.usi.ru" proxy="" port="" user="" password="" mmsc="http://mms" mmsproxy="192.168.168.192" mmsport="8080" type="mms" />
-  <apn carrier="Tele2 RU" mcc="250" mnc="20" apn="internet.tele2.ru" proxy="" port="" user="" password="" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="Tele2 RU MMS" mcc="250" mnc="20" apn="mms.tele2.ru" proxy="" port="" user="" password="" mmsc="http://mmsc.tele2.ru" mmsproxy="193.12.40.65" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="MegaFon Internet" mcc="250" mnc="30" apn="Internet" user="gdata" password="gdata" authtype="1" type="default,supl" />
-  <apn carrier="MegaFon MMS" mcc="250" mnc="30" apn="mms" mmsproxy="10.10.10.10" mmsport="8080" mmsc="http://mmsc:8002" user="mms" password="mms" authtype="1" type="mms" />
-  <apn carrier="USI GPRS" mcc="250" mnc="39" apn="internet.usi.ru" type="default,supl" />
-  <apn carrier="Utel MMS" mcc="250" mnc="39" apn="mms.usi.ru" mmsproxy="192.168.168.192" mmsport="8080" mmsc="http://mms" type="mms" />
-  <apn carrier="МТС-интернет" mcc="250" mnc="39" apn="internet.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="МТС Центр MMS" mcc="250" mnc="39" apn="mms.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="http://mmsc" mmsproxy="192.168.192.192" mmsport="8080" authtype="1" type="mms" />
   <apn carrier="Beeline internet" mcc="250" mnc="44" apn="internet.beeline.ru" proxy="" port="" user="beeline" password="beeline" mmsc="" authtype="1" type="default,supl" />
   <apn carrier="Beeline MMS" mcc="250" mnc="44" apn="mms.beeline.ru" proxy="" port="" user="beeline" password="beeline" mmsc="http://mms/" mmsproxy="192.168.94.23" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="МТС-интернет" mcc="250" mnc="92" apn="internet.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="МТС Центр MMS" mcc="250" mnc="92" apn="mms.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="http://mmsc" mmsproxy="192.168.192.192" mmsport="8080" authtype="1" type="mms" />
   <apn carrier="МТС-интернет" mcc="250" mnc="93" apn="internet.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="" authtype="1" type="default,supl" />
   <apn carrier="МТС Центр MMS" mcc="250" mnc="93" apn="mms.mts.ru" proxy="" port="" user="mts" password="mts" mmsc="http://mmsc" mmsproxy="192.168.192.192" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="BeeLine RU" mcc="250" mnc="99" apn="internet.beeline.ru" proxy="" port="" user="beeline" password="beeline" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="BeeLine RU MMS" mcc="250" mnc="99" apn="mms.beeline.ru" proxy="" port="" user="beeline" password="beeline" mmsc="http://mms/" mmsproxy="192.168.94.23" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="Beeline Home" mcc="250" mnc="99" apn="home.beeline.ru" user="beeline" password="beeline" authtype="1" type="default,supl" />
-  <apn carrier="Vodafone UA" mcc="255" mnc="01" apn="internet" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone UA MMS" mcc="255" mnc="01" apn="mms" proxy="" port="" user="" password="" mmsc="http://mms" mmsproxy="192.168.10.10" mmsport="8080" type="mms" />
   <apn carrier="Beeline UA" mcc="255" mnc="02" apn="www.ab.kyivstar.net" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="Beeline UA MMS" mcc="255" mnc="02" apn="mms.kyivstar.net" proxy="" port="" user="" password="" mmsc="http://mms.kyivstar.net/" mmsproxy="10.10.10.10" mmsport="8080" type="mms" />
   <apn carrier="Kyivstar" mcc="255" mnc="03" apn="www.kyivstar.net" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
@@ -1057,35 +948,84 @@
   <apn carrier="Cyfrowy Polsat MMS" mcc="260" mnc="12" apn="mms.cyfrowypolsat.pl" proxy="" port="" user="" password="" mmsc="http://mms.cyfrowypolsat.pl:8002" mmsproxy="79.171.2.33" mmsport="8080" type="mms" />
   <apn carrier="Aero2" mcc="260" mnc="17" apn="darmowy" type="default,supl" />
   <apn carrier="Truphone PL" mcc="260" mnc="33" apn="truphone.com" type="default,supl" />
-  <apn carrier="Telekom IMS" mcc="262" mnc="01" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" user_visible="false" />
-  <apn carrier="Telekom Internet" mcc="262" mnc="01" apn="internet.telekom" user="telekom" password="telekom" mmsc="http://mms.t-mobile.de/servlets/mms" mmsproxy="109.237.176.193" mmsport="8008" bearer_bitmask="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17" authtype="1" type="mms,default,supl,ia" protocol="IPV4V6" />
-  <apn carrier="Telekom Internet" mcc="262" mnc="01" apn="hos" user="telekom" password="telekom" mmsc="http://mms.t-mobile.de/servlets/mms" mmsproxy="109.237.176.193" mmsport="8008" bearer_bitmask="18" authtype="1" type="mms,supl" protocol="IPV4V6" user_visible="false" />
-  <apn carrier="Telekom Internet" mcc="262" mnc="01" apn="internet.telekom" user="telekom" password="telekom" authtype="1" mmsproxy="172.28.23.131" mmsc="http://mms.t-mobile.de/servlets/mms" mmsport="8008" mvno_match_data="debitel" mvno_type="spn" protocol="IP" />
-  <apn carrier="Vodafone DE" mcc="262" mnc="02" apn="" type="ia" protocol="IPV4V6" />
-  <apn carrier="Vodafone DE-MMS" mcc="262" mnc="02" apn="event.vodafone.de" mmsc="http://139.7.24.1/servlets/mms" mmsproxy="139.7.29.17" mmsport="80" type="mms" />
-  <apn carrier="Vodafone DE" mcc="262" mnc="02" apn="web.vodafone.de" type="default,supl" />
-  <apn carrier="E-Plus Internet" mcc="262" mnc="03" apn="internet.eplus.de" user="eplus" password="internet" authtype="1" type="default,supl" />
-  <apn carrier="E-Plus MMS" mcc="262" mnc="03" apn="mms.eplus.de" user="mms" password="eplus" mmsc="http://mms/eplus/" mmsproxy="212.23.97.153" mmsport="5080" authtype="1" type="mms" />
-  <apn carrier="O2 Internet" mcc="262" mnc="07" apn="internet" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.5" mmsport="8080" authtype="1" type="default,supl,mms" protocol="IP" roaming_protocol="IP" />
-  <apn carrier="O2 DE IMS" mcc="262" mnc="07" apn="ims" type="ims" protocol="IP" roaming_protocol="IP" />
-  <apn carrier="O2 Internet Prepaid" mcc="262" mnc="07" apn="pinternet.interkom.de" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.6" mmsport="8080" type="default,supl,mms" mvno_match_data="2620749" mvno_type="imsi" />
-  <apn carrier="Alice" mcc="262" mnc="07" apn="internet.partner1" authtype="0" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.41" mmsport="8080" mvno_type="spn" mvno_match_data="Alice" />
-  <apn carrier="Fonic Prepaid" mcc="262" mnc="07" apn="pinternet.interkom.de" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.6" mmsport="8080" type="default,supl,mms" mvno_match_data="26207515" mvno_type="imsi" />
-  <apn carrier="Lidl Mobile" mcc="262" mnc="07" apn="pinternet.interkom.de" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.6" mmsport="8080" type="default,supl,mms" mvno_match_data="26207520" mvno_type="imsi" />
-  <apn carrier="Tchibo Internet" mcc="262" mnc="07" apn="webmobil1" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.8" mmsport="8080" type="default,supl,mms" mvno_match_data="26207500" mvno_type="imsi" />
-  <apn carrier="O2 DE IMS" mcc="262" mnc="08" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" mvno_match_data="2620739" mvno_type="imsi" />
+  <apn carrier="T-Mobile Internet" mcc="262" mnc="01" apn="internet.t-mobile" proxy="" port="" user="t-mobile" password="tm" mmsc="" authtype="1" type="default,supl" />
+  <apn carrier="T-Mobile MMS" mcc="262" mnc="01" apn="internet.t-mobile" proxy="" port="" user="t-mobile" password="tm" mmsc="http://mms.t-mobile.de/servlets/mms" mmsproxy="172.028.023.131" mmsport="8008" authtype="1" type="mms" />
+  <apn carrier="Telekom DE-MMS" mcc="262" mnc="01" apn="internet.t-mobile" user="t-mobile" password="tm" mmsc="http://mms.t-mobile.de/servlets/mms" mmsproxy="172.28.23.131" mmsport="8008" type="mms" />
+  <apn carrier="Telekom DE" mcc="262" mnc="01" apn="internet.telekom" user="t-mobile" password="tm" type="default,supl" />
   <apn carrier="Lebara" mcc="262" mnc="01" apn="internet.t-mobile" proxy="" port="" user="t-mobile" password="tm" mmsc="http://mms.t-mobile.de/servlets/mms" mmsproxy="172.28.23.131" mmsport="8008" mvno_type="spn" mvno_match_data="Lebara" type="default,supl,mms" />
   <apn carrier="Lebara Internet" mcc="262" mnc="01" apn="internet.t-d1.de" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
+  <apn carrier="Callmobile Internet" mcc="262" mnc="01" apn="internet.t-d1.de" proxy="193.254.160.002" port="9201" user="T-Mobile" password="wap" mmsc="" authtype="1" type="default,supl" />
+  <apn carrier="callmobile.de" mcc="262" mnc="01" apn="internet.t-mobile" proxy="" port="" user="t-mobile" password="tm" mmsc="http://mms.t-mobile.de/servlets/mms" mmsproxy="172.28.23.131" mmsport="8008" mvno_type="spn" mvno_match_data="callmobile.de" type="default,supl,mms" />
+  <apn carrier="otelo web" mcc="262" mnc="02" apn="data.otelo.de" user="" password="" type="default,supl" />
+  <apn carrier="klarmobil MMS" mcc="262" mnc="02" apn="event.vodafone.de" proxy="" port="" user="" password="" mmsc="http://139.7.24.1/servlets/mms" mmsproxy="139.7.29.17" mmsport="80" mvno_type="spn" mvno_match_data="klarmobil" type="mms" />
+  <apn carrier="klarmobil" mcc="262" mnc="02" apn="web.vodafone.de" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="klarmobil" type="default,supl" />
+  <apn carrier="Otelo MMS" mcc="262" mnc="02" apn="event.otelo.de" proxy="" port="" user="" password="" mmsc="http://139.7.24.1/servlets/mms" mmsproxy="139.7.29.17" mmsport="80" mvno_type="spn" mvno_match_data="O.tel.o" type="mms" />
+  <apn carrier="Otelo Internet" mcc="262" mnc="02" apn="data.otelo.de" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="O.tel.o" type="default,supl" />
+  <apn carrier="Open Market: E-Plus Web" mcc="262" mnc="03" apn="internet.eplus.de" user="eplus" password="internet" authtype="3" type="default,supl" />
+  <apn carrier="Open Market: E-Plus WAP" mcc="262" mnc="03" apn="wap.eplus.de" proxy="212.23.97.9" port="8080" mmsc="" user="eplus" password="wap" authtype="3" type="default,supl" />
+  <apn carrier="Open Market: E-Plus MMS" mcc="262" mnc="03" apn="mms.eplus.de" proxy="" port="" mmsproxy="212.23.97.153" mmsport="5080" mmsc="http://mms/eplus/" user="mms" password="eplus" authtype="3" type="mms" />
+  <apn carrier="blau DE" mcc="262" mnc="03" apn="internet.eplus.de" user="blau" password="blau" type="default,supl" />
+  <apn carrier="blau DE MMS" mcc="262" mnc="03" apn="mms.eplus.de" user="mms" password="eplus" mmsc="http://mms/eplus" mmsproxy="212.23.97.153" mmsport="5080" type="mms" />
+  <apn carrier="E-Plus Internet" mcc="262" mnc="03" apn="internet.eplus.de" user="eplus" password="internet" type="default,supl" />
+  <apn carrier="E-Plus MMS" mcc="262" mnc="03" apn="mms.eplus.de" user="mms" password="eplus" mmsc="http://mms/eplus/" mmsproxy="212.23.97.153" mmsport="5080" type="mms" />
+  <apn carrier="Sipgate" mcc="262" mnc="03" apn="sipgate" user="sipgate" password="sipgate" type="default,supl,mms" authtype="2" />
+  <apn carrier="DE - Blauworld Web" mcc="262" mnc="03" apn="internet.eplus.de" proxy="" port="" user="blauworld" password="blauworld" mmsc="" mvno_type="spn" mvno_match_data="blauworld" authtype="1" type="default,supl" />
+  <apn carrier="Aldi Talk MMS" mcc="262" mnc="03" apn="mms.eplus.de" proxy="" port="" user="mms" password="eplus" mmsc="http://mms/eplus/" mmsproxy="212.23.97.153" mmsport="5080" mvno_type="spn" mvno_match_data="Aldi Talk" authtype="1" type="mms" />
+  <apn carrier="Aldi Talk Internet" mcc="262" mnc="03" apn="internet.eplus.de" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="Aldi Talk" type="default,supl" />
+  <apn carrier="Simyo MMS" mcc="262" mnc="03" apn="mms.eplus.de" proxy="" port="" user="simyo" password="simyo" mmsc="http://mms/eplus/" mmsproxy="212.23.97.153" mmsport="5080" mvno_type="spn" mvno_match_data="Simyo" type="mms" />
+  <apn carrier="Simyo Internet" mcc="262" mnc="03" apn="internet.eplus.de" proxy="" port="" user="simyo" password="simyo" mmsc="" mvno_type="spn" mvno_match_data="Simyo" type="default,supl" />
+  <apn carrier="E-Plus Web GPRS" mcc="262" mnc="05" apn="internet.eplus.de" proxy="" port="" user="eplus" password="internet" mmsc="" type="default,supl" />
+  <apn carrier="E-Plus MMS" mcc="262" mnc="05" apn="mms.eplus.de" proxy="" port="" user="mms" password="eplus" mmsc="http://mms/eplus/" mmsproxy="212.23.97.153" mmsport="5080" type="mms" />
+  <apn carrier="T-Mobile Internet" mcc="262" mnc="06" apn="internet.t-mobile" user="t-mobile" password="tm" mmsc="http://mms.t-mobile.de/servlets/mms" mmsproxy="172.28.23.131" mmsport="8008" type="default,supl,mms" />
+  <apn carrier="T-Mobile Internet" mcc="262" mnc="06" apn="internet.t-mobile" proxy="" port="" user="t-mobile" password="tm" mmsc="http://mms.t-mobile.de/servlets/mms" mmsproxy="172.28.23.131" mmsport="8008" type="default,supl,mms" />
+  <apn carrier="o2 Internet" mcc="262" mnc="07" apn="internet" user="" password="" type="default,supl" />
+  <apn carrier="o2 Internet prepaid" mcc="262" mnc="07" apn="pinternet.interkom.de" user="" password="" type="default,supl" />
+  <apn carrier="o2 MMS" mcc="262" mnc="07" apn="internet" proxy="" port="" mmsproxy="82.113.100.5" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" />
+  <apn carrier="o2" mcc="262" mnc="07" apn="internet" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.5" mmsport="8080" type="default,supl,mms" />
+  <apn carrier="O2 DE" mcc="262" mnc="07" apn="surfo2" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.5" mmsport="8080" type="default,supl,mms" />
+  <apn carrier="o2 Prepaid" mcc="262" mnc="07" apn="pinternet.interkom.de" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.6" mmsport="8080" type="default,supl,mms" />
+  <apn carrier="Tchibo Internet" mcc="262" mnc="07" apn="wapmobil2" user="" password="" type="default,supl" />
+  <apn carrier="Tchibo MMS" mcc="262" mnc="07" apn="wapmobil2" proxy="" port="" mmsproxy="82.113.100.8" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" spn="Tchibo" />
+  <apn carrier="Freenet Web GPRS" mcc="262" mnc="07" apn="internet.online" user="" password="" type="default,supl" />
+  <apn carrier="Freenet MMS" mcc="262" mnc="07" apn="internet" proxy="" port="" mmsproxy="82.113.100.45" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" spn="Freenet" />
+  <apn carrier="Alice Web" mcc="262" mnc="07" apn="internet.partner1" user="" password="" type="default,supl" />
+  <apn carrier="Alice MMS" mcc="262" mnc="07" apn="internet.partner1" proxy="" port="" mmsproxy="82.113.100.41" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" spn="Alice Mobile" />
+  <apn carrier="Alice MMS" mcc="262" mnc="07" apn="internet.partner1" proxy="" port="" user="" password="" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.41" mmsport="8080" mvno_type="spn" mvno_match_data="Alice" type="mms" />
+  <apn carrier="Alice Internet" mcc="262" mnc="07" apn="internet.partner1" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="Alice" type="default,supl" />
+  <apn carrier="Fonic MMS" mcc="262" mnc="07" apn="pinternet.interkom.de" proxy="" port="" user="" password="" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.6" mmsport="8080" mvno_type="pnn" mvno_match_data="FONIC" type="mms" />
+  <apn carrier="Fonic Internet" mcc="262" mnc="07" apn="pinternet.interkom.de" proxy="" port="" user="" password="" mmsc="" mvno_type="pnn" mvno_match_data="FONIC" type="default,supl" />
+  <apn carrier="Tchibo MMS" mcc="262" mnc="07" apn="wapmobil1" proxy="" port="" user="" password="" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.8" mmsport="8080" mvno_type="spn" mvno_match_data="Tchibo" type="mms" />
+  <apn carrier="Tchibo Internet" mcc="262" mnc="07" apn="webmobil1" proxy="" port="" user="" password="" mmsc="" mvno_type="spn" mvno_match_data="Tchibo" type="default,supl" />
+  <apn carrier="o2 Internet" mcc="262" mnc="08" apn="internet" user="" password="" type="default,supl" />
+  <apn carrier="o2 Internet prepaid" mcc="262" mnc="08" apn="pinternet.interkom.de" user="" password="" type="default,supl" />
+  <apn carrier="o2 MMS" mcc="262" mnc="08" apn="internet" proxy="" port="" mmsproxy="82.113.100.5" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" />
+  <apn carrier="Tchibo Internet" mcc="262" mnc="08" apn="wapmobil2" user="" password="" type="default,supl" />
+  <apn carrier="Tchibo MMS" mcc="262" mnc="08" apn="wapmobil2" proxy="" port="" mmsproxy="82.113.100.8" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" spn="Tchibo" />
+  <apn carrier="Freenet Web GPRS" mcc="262" mnc="08" apn="internet.online" user="" password="" type="default,supl" />
+  <apn carrier="Freenet MMS" mcc="262" mnc="08" apn="internet" proxy="" port="" mmsproxy="82.113.100.45" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" spn="Freenet" />
+  <apn carrier="Alice Web" mcc="262" mnc="08" apn="internet.partner1" user="" password="" type="default,supl" />
+  <apn carrier="Alice MMS" mcc="262" mnc="08" apn="internet.partner1" proxy="" port="" mmsproxy="82.113.100.41" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" spn="Alice Mobile" />
+  <apn carrier="o2" mcc="262" mnc="08" apn="internet" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.5" mmsport="8080" type="default,supl,mms" />
+  <apn carrier="O2" mcc="262" mnc="08" apn="internet" proxy="" port="" user="" password="" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.5" mmsport="8080" type="default,supl,mms" />
+  <apn carrier="Vodafone DE Web" mcc="262" mnc="02" apn="web.vodafone.de" proxy="" port="" type="default,supl" />
+  <apn carrier="Vodafone DE MMS" mcc="262" mnc="02" apn="event.vodafone.de" proxy="" port="" mmsproxy="139.007.029.017" mmsport="80" mmsc="http://139.7.24.1/servlets/mms" user="" password="" type="mms" />
+  <apn carrier="Vodafone DE-IMS" mcc="262" mnc="02" apn="ims" type="ims" protocol="IPV4V6" />
+  <apn carrier="o2 Internet" mcc="262" mnc="11" apn="internet" user="" password="" type="default,supl" />
+  <apn carrier="o2 Internet prepaid" mcc="262" mnc="11" apn="pinternet.interkom.de" user="" password="" type="default,supl" />
+  <apn carrier="o2 MMS" mcc="262" mnc="11" apn="internet" proxy="" port="" mmsproxy="82.113.100.5" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" />
+  <apn carrier="Tchibo Internet" mcc="262" mnc="11" apn="wapmobil2" user="" password="" type="default,supl" />
+  <apn carrier="Tchibo MMS" mcc="262" mnc="11" apn="wapmobil2" proxy="" port="" mmsproxy="82.113.100.8" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" spn="Tchibo" />
+  <apn carrier="Freenet Web GPRS" mcc="262" mnc="11" apn="internet.online" user="" password="" type="default,supl" />
+  <apn carrier="Freenet MMS" mcc="262" mnc="11" apn="internet" proxy="" port="" mmsproxy="82.113.100.45" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" spn="Freenet" />
+  <apn carrier="Alice Web" mcc="262" mnc="11" apn="internet.partner1" user="" password="" type="default,supl" />
+  <apn carrier="Alice MMS" mcc="262" mnc="11" apn="internet.partner1" proxy="" port="" mmsproxy="82.113.100.41" mmsport="8080" mmsc="http://10.81.0.7:8002" user="" password="" type="mms" spn="Alice Mobile" />
+  <apn carrier="O2" mcc="262" mnc="11" apn="internet" proxy="" port="" user="" password="" mmsc="http://10.81.0.7:8002" mmsproxy="82.113.100.5" mmsport="8080" type="default,supl,mms" />
   <apn carrier="Truphone" mcc="262" mnc="42" apn="truphone.com" type="default,dun" />
   <apn carrier="Lycamobile DE" mcc="262" mnc="43" apn="data.lycamobile.de" proxy="" port="" user="lmde" password="plus" mmsc="" mvno_type="spn" mvno_match_data="Lycamobile" type="default,supl" />
-  <apn carrier="Vodafone Net2" mcc="268" mnc="01" apn="net2.vodafone.pt" proxy="iproxy.vodafone.pt" port="80" mmsproxy="iproxy.vodafone.pt" mmsport="80" mmsc="http://mms.vodafone.pt/servlets/mms" user="vodafone" password="vodafone" authtype="3" type="default,mms" />
-  <apn carrier="Vodafone PT Internet" mcc="268" mnc="01" apn="net2.vodafone.pt" proxy="iproxy.vodafone.pt" port="80" mmsc="http://mms.vodafone.pt/servlets/mms" mmsproxy="iproxy.vodafone.pt" mmsport="80" type="default,supl,mms" />
-  <apn carrier="Vodafone PT WAP MMS" mcc="268" mnc="01" apn="vas.vodafone.pt" user="vas" password="vas" mmsc="http://mms/servlets/mms" mmsproxy="213.30.27.63" mmsport="8799" type="mms" />
-  <apn carrier="Vodafone PT WAP" mcc="268" mnc="01" apn="wap.vodafone.pt" user="wap" password="wap" proxy="172.16.19.50" port="8799" type="default,supl" />
   <apn carrier="NOS/WTF Internet" mcc="268" mnc="03" apn="umts" type="default,supl,dun" />
   <apn carrier="NOS MMS" mcc="268" mnc="03" apn="mms" mmsc="http://mmsc:10021/mmsc" mmsproxy="62.169.66.5" mmsport="8799" authtype="1" type="mms" />
   <apn carrier="WTF MMS" mcc="268" mnc="03" apn="umts" mmsc="http://mmsc:10021/mmsc" mmsproxy="62.169.66.5" mmsport="8799" authtype="1" type="mms" />
-  <apn carrier="Lycamobile PT" mcc="268" mnc="04" apn="data.lycamobile.pt" user="lmpt" password="plus" type="default,supl"/>
+  <apn carrier="Lycamobile PT" mcc="268" mnc="04" apn="data.lycamobile.pt" user="lmpt" password="plus" type="default,supl" />
   <apn carrier="Lycamobile" mcc="268" mnc="04" apn="data.lycamobile.pt" proxy="" port="" user="lmpt" password="plus" mmsc="" mvno_type="spn" mvno_match_data="Lycamobile" type="default,supl" />
   <apn carrier="MEO Internet" mcc="268" mnc="06" apn="internet" type="default,supl" />
   <apn carrier="MEO MMS" mcc="268" mnc="06" apn="mmsc.tmn.pt" user="tmn" password="tmnnet" mmsc="http://mmsc" mmsproxy="10.111.2.16" mmsport="8080" type="mms" />
@@ -1096,13 +1036,6 @@
   <apn carrier="Tango" mcc="270" mnc="77" apn="internet" proxy="" port="" user="" password="" mmsc="" authtype="1" type="default,supl" />
   <apn carrier="Tango MMS" mcc="270" mnc="77" apn="mms" proxy="" port="" user="tango" password="tango" mmsc="http://mms.tango.lu" mmsproxy="212.66.75.3" mmsport="8080" authtype="1" type="mms" />
   <apn carrier="Orange LU" mcc="270" mnc="99" apn="orange.lu" proxy="" port="" user="" password="" mmsc="http://mms.orange.lu" mmsproxy="212.88.139.44" mmsport="8080" authtype="1" type="default,supl,mms" />
-  <apn carrier="Tesco" mcc="272" mnc="01" apn="tescomobile.liffeytelecom.com" mmsc="http://mmc1/servlets/mms" mmsproxy="10.1.11.19" mmsport="8080" type="default,supl,mms" />
-  <apn carrier="Vodafone WAP" mcc="272" mnc="01" apn="live.vodafone.com" proxy="10.24.59.100" port="80" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone Internet" mcc="272" mnc="01" apn="isp.vodafone.ie" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone MMS" mcc="272" mnc="01" apn="mms.vodafone.net" proxy="" port="" user="" password="" mmsc="http://www.vodafone.ie/mms" mmsproxy="10.24.59.200" mmsport="80" type="mms" />
-  <apn carrier="Vodafone IE-ISP" mcc="272" mnc="01" apn="isp.vodafone.ie" proxy="" port="" user="vodafone" password="vodafone" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone IE" mcc="272" mnc="01" apn="live.vodafone.com" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone IE-MMS" mcc="272" mnc="01" apn="mms.vodafone.net" proxy="" port="" user="" password="" mmsc="http://www.vodafone.ie/mms" mmsproxy="10.24.59.200" mmsport="80" type="mms" />
   <apn carrier="O2 Internet" mcc="272" mnc="02" apn="internet" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="O2 WAP" mcc="272" mnc="02" apn="internet" proxy="62.40.32.40" port="8080" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="O2 MMS" mcc="272" mnc="02" apn="internet" proxy="" port="" user="" password="" mmsc="http://mmsc.mms.o2.ie:8002" mmsproxy="62.40.32.40" mmsport="8080" type="mms" />
@@ -1125,8 +1058,6 @@
   <apn carrier="Siminn Internet" mcc="274" mnc="01" apn="internet" proxy="213.167.138.200" port="8080" mmsc="" user="" password="" authtype="3" type="default,supl" />
   <apn carrier="Siminn MMS" mcc="274" mnc="01" apn="mms.simi.is" proxy="" port="" mmsproxy="213.167.138.200" mmsport="8080" mmsc="http://mms.simi.is/servlets/mms" user="" password="" authtype="3" type="mms" />
   <apn carrier="Siminn Internet" mcc="274" mnc="01" apn="internet" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone Internet" mcc="274" mnc="02" apn="gprs.is" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Vodafone MMS" mcc="274" mnc="02" apn="mms.gprs.is" proxy="" port="" user="" password="" mmsc="http://mmsc.vodafone.is" mmsproxy="10.22.0.10" mmsport="8080" type="mms" />
   <apn carrier="MMS Nova" mcc="274" mnc="11" apn="mms.nova.is" proxy="" port="" user="" password="" mmsc="http://mmsc.nova.is" mmsproxy="10.10.2.60" mmsport="8080" type="mms" />
   <apn carrier="Net Nova" mcc="274" mnc="11" apn="net.nova.is" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="Tal" mcc="274" mnc="12" apn="internet.tal.is" mmsc="http://mms.tal.is/servlets/mms" mmsproxy="213.167.138.210" mmsport="8080" type="default,supl,mms" />
@@ -1138,10 +1069,10 @@
   <apn carrier="Eagle Mobile" mcc="276" mnc="03" apn="internet" type="default,supl" />
   <apn carrier="Eagle Mobile MMS" mcc="276" mnc="03" apn="mms" mmsc="http://192.168.140.164:38090" mmsproxy="192.168.141.25" mmsport="80" type="mms" />
   <apn carrier="Plus" mcc="276" mnc="04" apn="plusweb" type="default,supl" />
-  <apn carrier="CYTA" mcc="280" mnc="01" apn="cytamobile" mmsc="http://mmsc.cyta.com.cy" mmsproxy="212.31.96.161" mmsport="8080" type="default,supl,mms"/>
-  <apn carrier="MTN MMS" mcc="280" mnc="10" apn="mms" user="mms" password="mms" mmsc="http://mms.mtn.com.cy/mmsc" mmsproxy="172.24.97.1" mmsport="3130" type="mms"/>
-  <apn carrier="MTN Internet" mcc="280" mnc="10" apn="internet" type="default,supl"/>
-  <apn carrier="PrimeTel" mcc="280" mnc="20" apn="ip.primetel" mmsc="http://mms.primetel" type="default,supl,mms"/>
+  <apn carrier="CYTA" mcc="280" mnc="01" apn="cytamobile" mmsc="http://mmsc.cyta.com.cy" mmsproxy="212.31.96.161" mmsport="8080" type="default,supl,mms" />
+  <apn carrier="MTN MMS" mcc="280" mnc="10" apn="mms" user="mms" password="mms" mmsc="http://mms.mtn.com.cy/mmsc" mmsproxy="172.24.97.1" mmsport="3130" type="mms" />
+  <apn carrier="MTN Internet" mcc="280" mnc="10" apn="internet" type="default,supl" />
+  <apn carrier="PrimeTel" mcc="280" mnc="20" apn="ip.primetel" mmsc="http://mms.primetel" type="default,supl,mms" />
   <apn carrier="Geocell" mcc="282" mnc="01" apn="internet" proxy="" port="" user="" password="" mmsc="" type="default,supl,mms" />
   <apn carrier="Geocell Mms" mcc="282" mnc="01" apn="mms" proxy="" port="" user="" password="" mmsc="http://mms.geocell.com.ge/cmmsc/post" mmsproxy="10.11.240.7" mmsport="8080" type="default,supl,mms" />
   <apn carrier="Beeline AM" mcc="283" mnc="01" apn="internet.beeline.am" proxy="" port="" user="internet" password="internet" mmsc="" type="default,supl" />
@@ -1161,14 +1092,6 @@
   <apn carrier="GLOBUL Internet" mcc="284" mnc="05" apn="globul" proxy="192.168.88.11" port="8004" user="globul" password="" mmsc="" type="default,supl" />
   <apn carrier="GLOBUL MMS" mcc="284" mnc="05" apn="mms.globul.bg" proxy="" port="" user="mms" password="" mmsc="http://mmsc1.mms.globul.bg:8002" mmsproxy="192.168.87.11" mmsport="8004" type="mms" />
   <apn carrier="Bulsatcom" mcc="284" mnc="11" apn="bulsat.com" type="default,supl" />
-  <apn carrier="Turkcell Internet" mcc="286" mnc="01" apn="Internet" user="" password="" type="default,supl" />
-  <apn carrier="Turkcell MMS" mcc="286" mnc="01" apn="mms" proxy="" port="" mmsproxy="212.252.169.217" mmsport="8080" mmsc="http://mms.turkcell.com.tr/servlets/mms" user="mms" password="mms" type="mms" />
-  <apn carrier="Turkcell" mcc="286" mnc="01" apn="internet" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Turkcell MMS" mcc="286" mnc="01" apn="mms" proxy="" port="" user="mms" password="mms" mmsc="http://mms.turkcell.com.tr/servlets/mms" mmsproxy="212.252.169.217" mmsport="9201" type="mms" />
-  <apn carrier="Vodafone TR" mcc="286" mnc="02" apn="internet" proxy="" port="" user="vodafone" password="vodafone" mmsc="" type="default,supl" protocol="IPV4V6" />
-  <apn carrier="Vodafone Live" mcc="286" mnc="02" apn="vflive" proxy="212.65.136.226" port="9401" mmsc="" user="vodafone" password="vodafone" authtype="3" type="default,supl" />
-  <apn carrier="Vodafone TR MMS" mcc="286" mnc="02" apn="mms" proxy="" port="" user="vodafone" password="vodafone" mmsc="http://217.31.233.18:6001/MM1Servlet" mmsproxy="217.31.233.18" mmsport="9401" type="mms" />
-  <apn carrier="MMS GPRS" mcc="286" mnc="02" apn="mms" proxy="" port="" mmsc="http://217.31.233.18:6001/MM1Servlet" user="vodafone" password="vodafone" authtype="3" type="mms" />
   <apn carrier="AVEA" mcc="286" mnc="03" apn="internet" proxy="" port="" user="wap" password="wap" mmsc="" type="default,supl" />
   <apn carrier="AVEA MMS" mcc="286" mnc="03" apn="mms" proxy="" port="" user="mms" password="mms" mmsc="http://mms.avea.com.tr/servlets/mms" mmsproxy="213.161.151.201" mmsport="8080" type="mms" />
   <apn carrier="Tele MMS" mcc="290" mnc="01" apn="internet" proxy="" port="" user="" password="" mmsc="http://mms.tele.gl/mms/wapenc" mmsproxy="10.112.222.37" mmsport="8080" type="mms" />
@@ -1191,65 +1114,67 @@
   <apn carrier="ProMonte MMS" mcc="297" mnc="01" apn="mms.promonte.com" proxy="" port="" user="mms" password="mms" mmsc="http://mm.vor.promonte.com" mmsproxy="192.168.246.5" mmsport="8080" type="mms" />
   <apn carrier="T-Mobile CG MMS" mcc="297" mnc="02" apn="mms" proxy="" port="" user="38267" password="38267" mmsc="http://192.168.180.100/servlets/mms" mmsproxy="10.0.5.19" mmsport="8080" type="mms" />
   <apn carrier="T-Mobile CG" mcc="297" mnc="02" apn="tmcg-wnw" proxy="" port="" user="38267" password="38267" mmsc="" type="default,supl" />
-  <apn carrier="TELUS SP" mcc="302" mnc="220" apn="sp.telus.com" type="default,mms,supl,hipri,ia" mmsc="http://aliasredirect.net/proxy/mmsc" mmsproxy="mmscproxy.mobility.ca" mmsport="8799" protocol="IPV6" roaming_protocol="IP" mvno_match_data="5455" mvno_type="gid" />
-  <apn carrier="TELUS ISP" mcc="302" mnc="220" apn="isp.telus.com" server="*" type="dun" protocol="IP" mvno_match_data="5455" mvno_type="gid" />
-  <apn carrier="TELUS IMS" mcc="302" mnc="220" apn="ims" type="ims" protocol="IPV6" mvno_match_data="5455" mvno_type="gid" user_visible="false" />
-  <apn carrier="Koodo SP" mcc="302" mnc="220" apn="sp.koodo.com" type="*" mmsc="http://aliasredirect.net/proxy/koodo/mmsc" mmsproxy="74.49.0.18" mmsport="80" protocol="IP" roaming_protocol="IP" mvno_match_data="4B4F" mvno_type="gid" />
-  <apn carrier="Koodo IMS" mcc="302" mnc="220" apn="ims" type="ims" protocol="IPV6" mvno_match_data="4B4F" mvno_type="gid" />
-  <apn carrier="Mobile Internet" mcc="302" mnc="220" apn="sp.mb.com" type="default,mms,supl" mmsc="http://aliasredirect.net/proxy/mb/mmsc" mmsproxy="74.49.0.18" mmsport="80" mvno_match_data="5043" mvno_type="gid" />
+  <apn carrier="Telus SP" mcc="302" mnc="220" apn="sp.telus.com" mmsc="http://aliasredirect.net/proxy/mmsc" mmsproxy="74.49.0.18" mmsport="80" mvno_match_data="54" mvno_type="gid" type="default,supl,mms" />
+  <apn carrier="TELUS ISP" mcc="302" mnc="220" apn="isp.telus.com" type="dun" mvno_type="gid" mvno_match_data="54" />
+  <apn carrier="Telus SP Tether" mcc="302" mnc="220" apn="isp.telus.com" mmsc="http://aliasredirect.net/proxy/mmsc" mmsproxy="74.49.0.18" mmsport="80" type="default,supl,mms" />
+  <apn carrier="Koodo SP" mcc="302" mnc="220" apn="sp.koodo.com" proxy="" port="" mmsc="http://aliasredirect.net/proxy/koodo/mmsc" mmsproxy="74.49.0.18" mmsport="80" mvno_match_data="4B" mvno_type="gid" type="default,supl,mms,dun" />
+  <apn carrier="Mobile Internet" mcc="302" mnc="220" apn="sp.mb.com" type="default,mms,supl" mmsc="http://aliasredirect.net/proxy/mb/mmsc" mmsproxy="74.49.0.18" mmsport="80" mvno_match_data="50" mvno_type="gid" />
   <apn carrier="Tethered Mobile Internet" mcc="302" mnc="220" apn="isp.mb.com" type="dun" mvno_type="gid" mvno_match_data="50" />
   <apn carrier="Mobile Internet" mcc="302" mnc="220" apn="sp.mb.com" type="default,mms,agps,supl,fota,hipri" mmsc="http://aliasredirect.net/proxy/mb/mmsc" mmsproxy="74.49.0.18" mmsport="80" mvno_type="gid" mvno_match_data="4D4F" />
   <apn carrier="Tethered Mobile Internet" mcc="302" mnc="220" apn="isp.mb.com" type="dun" mvno_type="gid" mvno_match_data="4D4F" />
   <apn carrier="Public Mobile" mcc="302" mnc="220" apn="sp.mb.com" mmsc="http://aliasredirect.net/proxy/mb/mmsc" mmsproxy="74.49.0.18" mmsport="80" mvno_match_data="50" mvno_type="gid" type="default,supl,mms" />
-  <apn carrier="TELUS SP" mcc="302" mnc="221" apn="sp.telus.com" type="default,mms,supl,hipri,ia" mmsc="http://aliasredirect.net/proxy/mmsc" mmsproxy="mmscproxy.mobility.ca" mmsport="8799" protocol="IPV6" roaming_protocol="IP" mvno_match_data="5455" mvno_type="gid" />
-  <apn carrier="TELUS ISP" mcc="302" mnc="221" apn="isp.telus.com" server="*" type="dun" protocol="IP" mvno_match_data="5455" mvno_type="gid" />
-  <apn carrier="TELUS IMS" mcc="302" mnc="221" apn="ims" type="ims" protocol="IPV6" mvno_match_data="5455" mvno_type="gid" user_visible="false" />
-  <apn carrier="Koodo SP" mcc="302" mnc="221" apn="sp.koodo.com" type="*" mmsc="http://aliasredirect.net/proxy/koodo/mmsc" mmsproxy="74.49.0.18" mmsport="80" protocol="IP" roaming_protocol="IP" mvno_match_data="4B4F" mvno_type="gid" />
-  <apn carrier="Koodo IMS" mcc="302" mnc="221" apn="ims" type="ims" protocol="IPV6" mvno_match_data="4B4F" mvno_type="gid" />
-  <apn carrier="PC mobile" mcc="302" mnc="221" apn="sp.mb.com" type="default,mms,supl" mmsc="http://aliasredirect.net/proxy/mb/mmsc" mmsproxy="74.49.0.18" mmsport="80" mvno_match_data="5043" mvno_type="gid" />
+  <apn carrier="Koodo SP" mcc="302" mnc="220" apn="sp.koodo.com" proxy="" port="" user="" password="" mmsc="http://aliasredirect.net/proxy/koodo/mmsc" mmsproxy="74.49.0.18" mmsport="80" type="default,supl,mms" />
+  <apn carrier="TELUS" mcc="302" mnc="221" apn="sp.telus.com" type="default,mms,supl" mmsc="http://aliasredirect.net/proxy/mmsc" mmsproxy="74.49.0.18" mmsport="80" mvno_match_data="54" mvno_type="gid" />
+  <apn carrier="Koodo" mcc="302" mnc="221" apn="sp.koodo.com" type="default,mms,supl" mmsc="http://aliasredirect.net/proxy/koodo/mmsc" mmsproxy="74.49.0.18" mmsport="80" mvno_match_data="4B" mvno_type="gid" />
+  <apn carrier="PC mobile" mcc="302" mnc="221" apn="sp.mb.com" type="default,mms,supl" mmsc="http://aliasredirect.net/proxy/mb/mmsc" mmsproxy="74.49.0.18" mmsport="80" mvno_match_data="50" mvno_type="gid" />
+  <apn carrier="MMS" mcc="302" mnc="270" apn="mms.mobi.eastlink.ca" mmsc="http://mmss.mobi.eastlink.ca" mmsproxy="10.232.12.49" mmsport="8080" type="mms" />
+  <apn carrier="Internet" mcc="302" mnc="270" apn="wisp.mobi.eastlink.ca" type="default,supl" />
+  <apn carrier="Eastlink Internet" mcc="302" mnc="270" apn="wisp.mobi.eastlink.ca" type="default,supl" />
   <apn carrier="Eastlink MMS" mcc="302" mnc="270" apn="mms.mobi.eastlink.ca" mmsc="http://mmss.mobi.eastlink.ca" mmsproxy="10.232.12.49" mmsport="8080" type="mms" />
-  <apn carrier="Eastlink Internet" mcc="302" mnc="270" apn="wisp.mobi.eastlink.ca" type="default,supl,dun,hipri" />
   <apn carrier="MOWAP" mcc="302" mnc="320" apn="wap.davewireless.com" proxy="10.100.3.4" port="8080" type="default,supl" />
   <apn carrier="MOMMS" mcc="302" mnc="320" apn="mms.davewireless.com" mmsc="http://mms.mobilicity.net" mmsproxy="10.100.3.4" mmsport="8080" type="mms" />
-  <apn carrier="Fido Internet" mcc="302" mnc="370" apn="ltemobile.apn" type="default,mms,agps,supl,fota,hipri,ia" mmsproxy="mmsproxy.fido.ca" mmsc="http://mms.fido.ca" mmsport="80" bearer_bitmask="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17" mvno_match_data="DD" mvno_type="gid" protocol="IPV4V6" roaming_protocol="IP" />
-  <apn carrier="Fido Netsvcs" mcc="302" mnc="370" apn="netsvcs" type="mms" mmsproxy="mmsproxy.fido.ca" mmsc="http://mms.fido.ca" mmsport="80" bearer_bitmask="18" mvno_match_data="DD" mvno_type="gid" protocol="IPV4V6" roaming_protocol="IP" user_visible="false" />
-  <apn carrier="Fido IMS" mcc="302" mnc="370" apn="ims" type="ims" mvno_match_data="DD" mvno_type="gid" protocol="IPV4V6" roaming_protocol="IPV4V6" user_visible="false" />
-  <apn carrier="Fido Tethering" mcc="302" mnc="370" apn="ltedata.apn" type="dun" mvno_match_data="DD" mvno_type="gid" protocol="IPV4V6" />
+  <apn carrier="Mobilicity MMS" mcc="302" mnc="320" apn="mms.davewireless.com" proxy="" port="" user="" password="" mmsc="http://mms.mobilicity.net" mmsproxy="10.100.3.4" mmsport="8080" type="mms" />
+  <apn carrier="Mobilicity" mcc="302" mnc="320" apn="wap.davewireless.com" proxy="" port="" user="dave" password="password" mmsc="" type="default,supl" />
+  <apn carrier="Fido Tethering" mcc="302" mnc="370" apn="ltedata.apn" type="dun" mvno_match_data="DD" mvno_type="gid" protocol="IPV4V6" roaming_protocol="IP" />
+  <apn carrier="Fido Internet" mcc="302" mnc="370" apn="ltemobile.apn" type="default,mms,agps,supl,fota,hipri" mmsproxy="mmsproxy.fido.ca" mmsc="http://mms.fido.ca" mmsport="80" mvno_match_data="DD" mvno_type="gid" protocol="IPV4V6" roaming_protocol="IP" />
   <apn carrier="MTS" mcc="302" mnc="370" apn="sp.mts" type="default,mms,supl" mmsc="http://mmsc2.mts.net/" mmsproxy="wapgw1.mts.net" mmsport="9201" protocol="IPV4V6" roaming_protocol="IPV4V6" mvno_match_data="2C" mvno_type="gid" />
   <apn carrier="MTS Tethering S" mcc="302" mnc="370" apn="internet.mts" type="dun" protocol="IPV4V6" roaming_protocol="IP" mvno_type="gid" mvno_match_data="2C" />
-  <apn carrier="Freedom Mobile Internet" mcc="302" mnc="490" apn="internet.freedommobile.ca" type="default,dun,supl" protocol="IPV4V6" user_editable="false" />
-  <apn carrier="Freedom Mobile MMS" mcc="302" mnc="490" apn="mms.freedommobile.ca" mmsc="http://mms.windmobile.ca" mmsproxy="74.115.197.70" mmsport="8080" type="mms" user_editable="false" />
-  <apn carrier="Freedom Mobile VoLTE" mcc="302" mnc="490" apn="volte.mobilefrdm.ca" type="ims" protocol="IPV4V6" user_visible="false" />
-  <apn carrier="Freedom Mobile E911" mcc="302" mnc="490" apn="e911.mobilefrdm.ca" type="emergency" protocol="IPV4V6" user_visible="false" />
-  <apn carrier="Videotron Mobile" mcc="302" mnc="500" apn="media.ng" mmsc="http://media.videotron.com" mmsproxy="10.208.89.17" mmsport="8080" type="default,supl,mms" user_editable="false" />
-  <apn carrier="Videotron Mobile LTE IMS" mcc="302" mnc="500" apn="ims" type="ims" protocol="IPV6" roaming_protocol="IPV6" user_visible="false" />
-  <apn carrier="Videotron Mobile Emergency" mcc="302" mnc="500" apn="sos" type="emergency" protocol="IPV6" roaming_protocol="IPV6" user_visible="false" />
-  <apn carrier="Videotron Mobile" mcc="302" mnc="510" apn="media.ng" mmsc="http://media.videotron.com" mmsproxy="10.208.89.17" mmsport="8080" type="default,supl,mms" />
-  <apn carrier="Videotron Mobile" mcc="302" mnc="520" apn="media.ng" mmsc="http://media.videotron.com" mmsproxy="10.208.89.17" mmsport="8080" type="default,supl,mms" />
-  <apn carrier="Bell Mobility" mcc="302" mnc="610" apn="pda.bell.ca" type="default,mms,supl,dun,hipri,ia" mmsc="http://mms.bell.ca/mms/wapenc" protocol="IPV4V6" roaming_protocol="IP" />
-  <apn carrier="Bell Mobility IMS" mcc="302" mnc="610" apn="ims" type="ims" protocol="IPV4V6" />
-  <apn carrier="Virgin Mobile" mcc="302" mnc="610" apn="pda.bell.ca" type="default,mms,supl" mmsc="http://mms.bell.ca/mms/wapenc" authtype="2" mvno_type="gid" mvno_match_data="62" />
-  <apn carrier="Virgin Mobile IMS" mcc="302" mnc="610" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" authtype="2" mvno_type="gid" mvno_match_data="62" />
-  <apn carrier="Bell Mobility Test IMS" mcc="302" mnc="630" apn="ims" type="ims" protocol="IPV4V6" />
-  <apn carrier="Bell Mobility Test IMS" mcc="302" mnc="640" apn="ims" type="ims" protocol="IPV4V6" />
-  <apn carrier="MTS" mcc="302" mnc="660" apn="sp.mts" type="default,mms,supl" mmsc="http://mmsc2.mts.net/" mmsproxy="wapgw1.mts.net" mmsport="9401" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Fido LTE" mcc="302" mnc="370" apn="ltemobile.apn" mmsc="http://mms.fido.ca" mmsproxy="205.151.11.13" mmsport="80" type="default,supl,mms" protocol="IPV4V6" roaming_protocol="IP" />
+  <apn carrier="Fido Default" mcc="302" mnc="370" apn="fido-core-appl1.apn" proxy="" port="" user="" password="" mmsc="http://mms.fido.ca" mmsproxy="205.151.11.13" mmsport="80" type="default,supl,mms" />
+  <apn carrier="Fido Internet" mcc="302" mnc="370" apn="internet.fido.ca" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
+  <apn carrier="Fido Tethering" mcc="302" mnc="370" apn="isp.fido.apn" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
+  <apn carrier="Internet" mcc="302" mnc="490" apn="internet.windmobile.ca" user="" password="" type="default,supl" />
+  <apn carrier="MMS" mcc="302" mnc="490" apn="mms.windmobile.ca" proxy="" port="" mmsproxy="74.115.197.70" mmsport="8080" mmsc="http://mms.windmobile.ca" user="" password="" type="mms" />
+  <apn carrier="Wind CA" mcc="302" mnc="490" apn="internet.windmobile.ca" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
+  <apn carrier="Wind CA MMS" mcc="302" mnc="490" apn="mms.windmobile.ca" proxy="" port="" user="" password="" mmsc="http://mms.windmobile.ca" mmsproxy="74.115.197.70" mmsport="8080" type="mms" />
+  <apn carrier="Videotron" mcc="302" mnc="500" apn="media.videotron" proxy="" port="" user="" password="" mmsc="http://media.videotron.com/" mmsproxy="10.208.89.17" mmsport="8080" type="default,supl,mms" />
+  <apn carrier="Media" mcc="302" mnc="500" apn="media.ng" mmsc="http://media.videotron.com" type="default,supl,mms" />
+  <apn carrier="Media" mcc="302" mnc="510" apn="media.ng" mmsc="http://media.videotron.com" type="default,supl,mms" />
+  <apn carrier="Media" mcc="302" mnc="520" apn="media.ng" mmsc="http://media.videotron.com" type="default,supl,mms" />
+  <apn carrier="Virgin Mobile" mcc="302" mnc="610" apn="pda.stm.sk.ca" proxy="web.wireless.bell.ca" port="80" type="default,mms,supl" mmsc="http://mms.bell.ca/mms/wapenc" mmsproxy="web.wireless.bell.ca" mmsport="80" />
+  <apn carrier="Bell" mcc="302" mnc="610" apn="pda.bell.ca" proxy="web.wireless.bell.ca" port="80" user="" password="" mmsc="http://mms.bell.ca/mms/wapenc" mmsproxy="web.wireless.bell.ca" mmsport="80" type="" />
+  <apn carrier="Bell Flex" mcc="302" mnc="610" apn="inet.bell.ca" proxy="" port="" user="" password="" mmsc="http://mms.bell.ca/mms/wapenc" type="default,supl,mms" />
+  <apn carrier="MTS" mcc="302" mnc="660" apn="sp.mts" type="default,mms,supl" mmsc="http://mmsc2.mts.net/" mmsproxy="wapgw1.mts.net" mmsport="9201" protocol="IPV4V6" roaming_protocol="IPV4V6" mvno_match_data="2C" mvno_type="gid" />
   <apn carrier="MTS Tethering" mcc="302" mnc="660" apn="internet.mts" type="dun" protocol="IPV4V6" roaming_protocol="IP" mvno_type="gid" mvno_match_data="2C" />
+  <apn carrier="Rogers LTE" mcc="302" mnc="720" apn="ltemobile.apn" mmsc="http://mms.gprs.rogers.com" mmsproxy="10.128.1.69" mmsport="80" mvno_type="spn" mvno_match_data="ROGERS" type="default,supl,mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Rogers Tethering" mcc="302" mnc="720" apn="ltedata.apn" type="dun" mvno_match_data="ROGERS" mvno_type="spn" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Rogers" mcc="302" mnc="720" apn="rogers-core-appl1.apn" proxy="" port="" user="" password="" mmsc="http://mms.gprs.rogers.com" mmsproxy="10.128.1.69" mmsport="80" type="default,supl,mms" />
+  <apn carrier="Rogers Tethering" mcc="302" mnc="720" apn="isp.apn" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
+  <apn carrier="Rogers WAP" mcc="302" mnc="720" apn="internet.com" proxy="" port="" user="" password="wap" mmsc="" type="default,supl,mms" />
   <apn carrier="chatr" mcc="302" mnc="720" apn="chatrweb.apn" type="default,mms,supl" mmsc="http://mms.chatrwireless.com" mmsproxy="205.151.11.11" mmsport="80" proxy="205.151.11.11" port="80" protocol="IPV4V6" roaming_protocol="IPV4V6" mvno_match_data="302720x94" mvno_type="imsi" />
   <apn carrier="Chatr Tethering" mcc="302" mnc="720" apn="chatrisp.apn" type="dun" mvno_type="imsi" mvno_match_data="302720x94" protocol="IPV4V6" roaming_protocol="IP" />
-  <apn carrier="Tbaytel Internet" mnc="720" mcc="302" apn="ltemobile.apn" type="default,mms,agps,supl,fota,hipri" protocol="IPV4V6" roaming_protocol="IP" mmsc="http://mms.gprs.rogers.com" mmsproxy="mmsproxy.rogers.com" mmsport="80" mvno_type="gid" mvno_match_data="BA" />
-  <apn carrier="Tbaytel Tethering" mnc="720" mcc="302" apn="ltedata.apn" type="dun" protocol="IPV4V6" roaming_protocol="IP" mvno_type="gid" mvno_match_data="BA" />
-  <apn carrier="Cityfone Internet" mnc="720" mcc="302" apn="ltemobile.apn" type="default,mms,agps,supl,fota,hipri" protocol="IPV4V6" roaming_protocol="IP" mmsc="http://mms.gprs.rogers.com" mmsproxy="mmsproxy.rogers.com" mmsport="80" mvno_type="spn" mvno_match_data="CITYFONE" />
-  <apn carrier="Cityfone Tethering" mnc="720" mcc="302" apn="ltedata.apn" type="dun" protocol="IPV4V6" roaming_protocol="IP" mvno_type="spn" mvno_match_data="CITYFONE" />
+  <apn carrier="Tbaytel Tethering" mcc="302" mnc="720" apn="ltedata.apn" type="dun" protocol="IPV4V6" roaming_protocol="IP" mvno_type="gid" mvno_match_data="BA" />
+  <apn carrier="Tbaytel Internet" mcc="302" mnc="720" apn="ltemobile.apn" type="default,mms,agps,supl,fota,hipri" protocol="IPV4V6" roaming_protocol="IP" mmsc="http://mms.gprs.rogers.com" mmsproxy="mmsproxy.rogers.com" mmsport="80" mvno_type="gid" mvno_match_data="BA" />
+  <apn carrier="Cityfone Tethering" mcc="302" mnc="720" apn="ltedata.apn" type="dun" protocol="IPV4V6" roaming_protocol="IP" mvno_type="spn" mvno_match_data="CITYFONE" />
+  <apn carrier="Cityfone Internet" mcc="302" mnc="720" apn="ltemobile.apn" type="default,mms,agps,supl,fota,hipri" protocol="IPV4V6" roaming_protocol="IP" mmsc="http://mms.gprs.rogers.com" mmsproxy="mmsproxy.rogers.com" mmsport="80" mvno_type="spn" mvno_match_data="CITYFONE" />
   <apn carrier="Petro-Canada Mobility" mcc="302" mnc="720" apn="rogers-core-appl1.apn" type="default,mms,supl" mmsproxy="mmsproxy.rogers.com" mmsc="http://mms.gprs.rogers.com" mmsport="80" protocol="IPV4V6" />
-  <apn carrier="Rogers IMS" mcc="302" mnc="720" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" user_visible="false" />
-  <apn carrier="Rogers Internet" mcc="302" mnc="720" apn="ltemobile.apn" type="default,mms,supl,hipri,ia" mmsproxy="mmsproxy.rogers.com" mmsc="http://mms.gprs.rogers.com" mmsport="80" bearer_bitmask="1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17" protocol="IPV4V6" roaming_protocol="IPV4V6" />
-  <apn carrier="Rogers Netsvcs" mcc="302" mnc="720" apn="netsvcs" type="mms" mmsproxy="mmsproxy.rogers.com" mmsc="http://mms.gprs.rogers.com" mmsport="80" bearer_bitmask="18" protocol="IPV4V6" roaming_protocol="IPV4V6" user_visible="false" />
-  <apn carrier="Rogers Tethering" mcc="302" mnc="720" apn="ltedata.apn" type="dun" protocol="IPV4V6" roaming_protocol="IPV4V6" />
-  <apn carrier="SaskTel" mcc="302" mnc="780" apn="pda.stm.sk.ca" type="default,mms,supl" mmsc="http://mms.sasktel.com/" mmsproxy="mig.sasktel.com" mmsport="80" protocol="IP" roaming_protocol="IP" />
-  <apn carrier="Verizon Internet" mcc="310" mnc="00" apn="VZWINTERNET" type="default,dun,mms" mmsc="http://mms.vtext.com/servlets/mms" protocol="IPV4V6" roaming_protocol="IPV4V6"/>
-  <apn carrier="Verizon FOTA" mcc="310" mnc="00" apn="VZWADMIN" type="fota" protocol="IPV4V6" roaming_protocol="IPV4V6"/>
-  <apn carrier="Verizon IMS" mcc="310" mnc="00" apn="VZWIMS" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6"/>
-  <apn carrier="Verizon CBS" mcc="310" mnc="00" apn="VZWAPP" type="cbs,mms" mmsc="http://mms.vtext.com/servlets/mms" protocol="IPV4V6" roaming_protocol="IPV4V6"/>
+  <apn carrier="SaskTel" mcc="302" mnc="780" apn="pda.stm.sk.ca" type="default,mms,supl" mmsc="http://mms.sasktel.com/" mmsproxy="mig.sasktel.com" mmsport="80" />
+  <apn carrier="Sasktel 3G" mcc="302" mnc="780" apn="inet.stm.sk.ca" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
+  <apn carrier="Sasktel MMS" mcc="302" mnc="780" apn="proxy.stm.sk.ca" proxy="" port="80" user="" password="" mmsc="http://mms.sasktel.com" mmsproxy="mig.sasktel.com" mmsport="80" type="mms" />
+  <apn carrier="Verizon Internet" mcc="310" mnc="00" apn="VZWINTERNET" type="default,dun,mms" mmsc="http://mms.vtext.com/servlets/mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Verizon FOTA" mcc="310" mnc="00" apn="VZWADMIN" type="fota" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Verizon IMS" mcc="310" mnc="00" apn="VZWIMS" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Verizon CBS" mcc="310" mnc="00" apn="VZWAPP" type="cbs,mms" mmsc="http://mms.vtext.com/servlets/mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
   <apn carrier="Verizon Internet" mcc="310" mnc="002" apn="VZWINTERNET" type="default,dun,mms" mmsc="http://mms.vtext.com/servlets/mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
   <apn carrier="Verizon FOTA" mcc="310" mnc="002" apn="VZWADMIN" type="fota" protocol="IPV4V6" roaming_protocol="IPV4V6" />
   <apn carrier="Verizon IMS" mcc="310" mnc="002" apn="VZWIMS" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
@@ -1286,9 +1211,9 @@
   <apn carrier="Internet" mcc="310" mnc="090" apn="isp" type="default,supl" />
   <apn carrier="MMS" mcc="310" mnc="090" apn="mms" mmsc="http://mms.edgemobile.net/mmsc" mmsproxy="12.108.12.13" mmsport="3128" type="mms" />
   <apn carrier="Edge MMS Prepay" mcc="310" mnc="090" apn="ppmms" mmsc="http://mms.edgemobile.net/mmsc" mmsproxy="12.108.12.13" mmsport="3128" type="mms" />
-  <apn carrier="LTE INTERNET" mcc="310" mnc="090" apn="4g.mycricket.com" user="" password="" type="default,dun,mms" authtype="0" mmsc="http://mms.mycricket.com/servlets/mms" protocol="IP" roaming_protocol="IP" bearer="14"/>
-  <apn carrier="LTE ADMIN" mcc="310" mnc="090" apn="Apnota.4g.mycricket.com" user="" password="" type="fota" authtype="0" mmsc="http://mms.mycricket.com/servlets/mms" protocol="IP" roaming_protocol="IP" bearer="14"/>
-  <apn carrier="LTE DNSADMIN" mcc="310" mnc="090" apn="apndnsota.4g.mycricket.com" user="" password="" type="fota" authtype="0" mmsc="http://mms.mycricket.com/servlets/mms" protocol="IP" roaming_protocol="IP" bearer="14"/>
+  <apn carrier="LTE INTERNET" mcc="310" mnc="090" apn="4g.mycricket.com" user="" password="" type="default,dun,mms" authtype="0" mmsc="http://mms.mycricket.com/servlets/mms" protocol="IP" roaming_protocol="IP" bearer="14" />
+  <apn carrier="LTE ADMIN" mcc="310" mnc="090" apn="Apnota.4g.mycricket.com" user="" password="" type="fota" authtype="0" mmsc="http://mms.mycricket.com/servlets/mms" protocol="IP" roaming_protocol="IP" bearer="14" />
+  <apn carrier="LTE DNSADMIN" mcc="310" mnc="090" apn="apndnsota.4g.mycricket.com" user="" password="" type="fota" authtype="0" mmsc="http://mms.mycricket.com/servlets/mms" protocol="IP" roaming_protocol="IP" bearer="14" />
   <apn carrier="Internet" mcc="310" mnc="090" apn="isp" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="MMS" mcc="310" mnc="090" apn="mms" proxy="" port="" user="" password="" mmsc="http://mms.edgemobile.net/mmsc" mmsproxy="12.108.12.13" mmsport="3128" type="mms" />
   <apn carrier="Edge MMS Prepay" mcc="310" mnc="090" apn="ppmms" proxy="" port="" user="" password="" mmsc="http://mms.edgemobile.net/mmsc" mmsproxy="12.108.12.13" mmsport="3128" type="mms" />
@@ -1544,15 +1469,10 @@
   <apn carrier="GCI MMS" mcc="311" mnc="370" apn="mms.gci" proxy="" port="" user="" password="" mmsc="http://mmsc.gci.csky.us:6672" mmsproxy="209.4.229.92" mmsport="9201" type="mms" />
   <apn carrier="ATT WAP" mcc="311" mnc="380" apn="wap.cingular" proxy="wireless.cingular.com" port="80" mmsc="http://mmsc.cingular.com" mmsproxy="wireless.cingular.com" mmsport="80" type="default,mms" />
   <apn carrier="ATT Broadband" mcc="311" mnc="380" apn="Broadband" type="default,supl" />
-  <!-- bearer 4, 5, 6, 7, 8, 12 -->
   <apn carrier="Verizon" mcc="311" mnc="480" apn="internet" authtype="3" type="default,mms,supl,fota,cbs,dun" mmsc="http://mms.vtext.com/servlets/mms" protocol="IPV4V6" bearer_bitmask="4|5|6|7|8|12" user_visible="false" />
-  <!-- bearer 1, 2, 3, 9, 10, 11, 13, 14, 15, 18 -->
   <apn carrier="Verizon" mcc="311" mnc="480" apn="VZWINTERNET" type="default,dun,supl" authtype="0" protocol="IPV4V6" roaming_protocol="IP" bearer_bitmask="1|2|3|9|10|11|13|14|15|18" profile_id="0" modem_cognitive="true" max_conns="20" max_conns_time="300" />
-  <!-- bearer 1, 2, 3, 9, 10, 11, 13, 14, 15, 18 -->
-  <apn carrier="Verizon" mcc="311" mnc="480" apn="VZWADMIN" type="fota" authtype="0" protocol="IPV4V6" roaming_protocol="IP" bearer_bitmask="1|2|3|9|10|11|13|14|15|18" profile_id="3" modem_cognitive="true" max_conns="20" max_conns_time="300" user_visible="false"  />
-  <!-- bearer 1, 2, 3, 9, 10, 11, 13, 14, 15, 18 -->
+  <apn carrier="Verizon" mcc="311" mnc="480" apn="VZWADMIN" type="fota" authtype="0" protocol="IPV4V6" roaming_protocol="IP" bearer_bitmask="1|2|3|9|10|11|13|14|15|18" profile_id="3" modem_cognitive="true" max_conns="20" max_conns_time="300" user_visible="false" />
   <apn carrier="Verizon" mcc="311" mnc="480" apn="IMS" type="ims,ia" authtype="0" protocol="IPV4V6" roaming_protocol="IPV6" bearer_bitmask="1|2|3|9|10|11|13|14|15|18" profile_id="2" modem_cognitive="true" max_conns="20" max_conns_time="300" user_visible="false" />
-  <!-- bearer 1, 2, 3, 9, 10, 11, 13, 14, 15, 18 -->
   <apn carrier="Verizon" mcc="311" mnc="480" apn="VZWAPP" type="cbs,mms" authtype="0" mmsc="http://mms.vtext.com/servlets/mms" protocol="IPV4V6" roaming_protocol="IP" bearer_bitmask="1|2|3|9|10|11|13|14|15|18" profile_id="4" modem_cognitive="true" max_conns="20" max_conns_time="300" user_visible="false" />
   <apn carrier="StraightTalk Verizon" mcc="311" mnc="480" apn="TRACFONE.VZWENTP" type="default,dun,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
   <apn carrier="XFINITY Mobile" mcc="311" mnc="480" apn="COMCAST.RSLR.VZWENTP" type="default,dun,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
@@ -1752,8 +1672,8 @@
   <apn carrier="Bmobile MMS" mcc="374" mnc="12" apn="mms" mmsproxy="192.168.210.104" mmsport="8080" mmsc="http://192.168.210.104/mmrelay.app" user="" password="" type="mms" />
   <apn carrier="BMobile Postpaid" mcc="374" mnc="12" apn="internet" type="default,supl" port="8080" />
   <apn carrier="BMobile Prepaid" mcc="374" mnc="12" apn="bconnected" type="default,supl" port="8080" />
-  <apn carrier="BMobile MMS" mcc="374" mnc="12" apn="mms" type="mms" mmsc="http://192.168.210.104/mmrelay.app" mmsproxy="192.168.210.104" mmsport="8080"/>
-  <apn carrier="BMobile Buzz" mcc="374" mnc="12" apn="buzz" type="default,mms" proxy="192.168.210.104" port="8080" mmsc="http://192.168.210.103/operator/wap"/>
+  <apn carrier="BMobile MMS" mcc="374" mnc="12" apn="mms" type="mms" mmsc="http://192.168.210.104/mmrelay.app" mmsproxy="192.168.210.104" mmsport="8080" />
+  <apn carrier="BMobile Buzz" mcc="374" mnc="12" apn="buzz" type="default,mms" proxy="192.168.210.104" port="8080" mmsc="http://192.168.210.103/operator/wap" />
   <apn carrier="Digicel Web" mcc="374" mnc="13" apn="web" user="" password="" type="default,supl" />
   <apn carrier="Digicel MMS" mcc="374" mnc="13" apn="wap" proxy="" port="" mmsproxy="172.20.6.12" mmsport="8080" mmsc="http://mmc.digiceltt.com/servlets/mms" user="wap" password="wap" type="mms" />
   <apn carrier="Digicel TT" mcc="374" mnc="13" apn="web.digiceltt.com" type="default,supl" />
@@ -1804,24 +1724,20 @@
   <apn carrier="MTS WAP" mcc="404" mnc="00" apn="WAP" user="wap@wap.mtsindia.in" password="MTS" authtype="3" type="default,supl" />
   <apn carrier="MTS MMS" mcc="404" mnc="00" apn="MMS" user="mms@mms.mtsindia.in" password="MTS" authtype="3" type="mms" />
   <apn carrier="MTS MODEM" mcc="404" mnc="00" apn="Modem" user="internet@internet.mtsindia.in" password="MTS" authtype="3" type="default,supl" />
-  <apn carrier="Vodafone" mcc="404" mnc="01" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="01" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="01" apn="www" type="default,supl" />
-  <apn carrier="RCOM" mcc="404" mnc="13" apn="rcomnet" type="default,supl" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="02" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="02" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="02" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="02" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" authtype="1" type="mms" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="03" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="03" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="03" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="03" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" authtype="1" type="mms" />
   <apn carrier="IDEA Internet" mcc="404" mnc="04" apn="internet" type="default,supl" />
   <apn carrier="IDEA Wap" mcc="404" mnc="04" apn="imis" proxy="10.4.42.15" port="8080" type="default,supl" />
   <apn carrier="IDEA MMS" mcc="404" mnc="04" apn="mmsc" mmsc="http://10.4.42.21:8002" mmsproxy="10.4.42.15" mmsport="8080" type="mms" />
   <apn carrier="IDEA Mobile" mcc="404" mnc="04" apn="mobile" type="default,supl" />
-  <apn carrier="Vodafone" mcc="404" mnc="05" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="05" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="05" apn="www" type="default,supl" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="06" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="06" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="06" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="06" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="IDEA Internet" mcc="404" mnc="07" apn="internet" type="default,supl" />
@@ -1839,8 +1755,6 @@
   <apn carrier="IMS" mcc="405" mnc="855" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" user_visible="false" />
   <apn carrier="Jio 4G" mcc="405" mnc="856" apn="jionet" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
   <apn carrier="IMS" mcc="405" mnc="856" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" user_visible="false" />
-  <apn carrier="Jio 4G" mcc="405" mnc="857" apn="jionet" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
-  <apn carrier="IMS" mcc="405" mnc="857" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" user_visible="false" />
   <apn carrier="Jio 4G" mcc="405" mnc="858" apn="jionet" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
   <apn carrier="IMS" mcc="405" mnc="858" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" user_visible="false" />
   <apn carrier="Jio 4G" mcc="405" mnc="859" apn="jionet" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
@@ -1880,27 +1794,20 @@
   <apn carrier="Reliance RTel" mcc="404" mnc="09" apn="SMARTNET" type="default,supl" />
   <apn carrier="Reliance WAP" mcc="404" mnc="09" apn="rcomwap" proxy="10.239.221.5" port="8080" type="default,supl" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="10" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="10" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="10" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="10" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
-  <apn carrier="Vodafone" mcc="404" mnc="11" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="11" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="11" apn="www" type="default,supl" />
   <apn carrier="IDEA Internet" mcc="404" mnc="12" apn="internet" type="default,supl" />
   <apn carrier="IDEA Wap" mcc="404" mnc="12" apn="imis" proxy="10.4.42.15" port="8080" type="default,supl" />
   <apn carrier="IDEA MMS" mcc="404" mnc="12" apn="mmsc" mmsc="http://10.4.42.21:8002" mmsproxy="10.4.42.15" mmsport="8080" type="mms" />
   <apn carrier="IDEA Mobile" mcc="404" mnc="12" apn="mobile" type="default,supl" />
-  <apn carrier="Vodafone" mcc="404" mnc="13" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="13" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="13" apn="www" type="default,supl" />
   <apn carrier="IDEA Internet" mcc="404" mnc="14" apn="internet" type="default,supl" />
   <apn carrier="IDEA Wap" mcc="404" mnc="14" apn="imis" proxy="10.4.42.15" port="8080" type="default,supl" />
   <apn carrier="IDEA MMS" mcc="404" mnc="14" apn="mmsc" mmsc="http://10.4.42.21:8002" mmsproxy="10.4.42.15" mmsport="8080" type="mms" />
   <apn carrier="SPICE" mcc="404" mnc="14" apn="spicegprs" type="default,supl" />
   <apn carrier="SPICE MMS" mcc="404" mnc="14" apn="spicemms" user="User Mobile number" password="spice" mmsc="http://10.200.200.3:8514" mmsproxy="10.200.200.3" mmsport="8080" type="mms" />
-  <apn carrier="Vodafone" mcc="404" mnc="15" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="15" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="15" apn="www" type="default,supl" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="16" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="16" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="16" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="16" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Aircel Online" mcc="404" mnc="17" apn="aircelgprs" type="default,supl" />
@@ -1915,9 +1822,6 @@
   <apn carrier="IDEA Wap" mcc="404" mnc="19" apn="imis" proxy="10.4.42.15" port="8080" type="default,supl" />
   <apn carrier="IDEA MMS" mcc="404" mnc="19" apn="mmsc" mmsc="http://10.4.42.21:8002" mmsproxy="10.4.42.15" mmsport="8080" type="mms" />
   <apn carrier="IDEA Mobile" mcc="404" mnc="19" apn="mobile" type="default,supl" />
-  <apn carrier="Vodafone" mcc="404" mnc="20" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="20" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="20" apn="www" type="default,supl" />
   <apn carrier="Loop Internet" mcc="404" mnc="21" apn="www" type="default,supl" />
   <apn carrier="LOOP WAP" mcc="404" mnc="21" apn="mizone" proxy="10.0.0.10" port="9401" user="Mobile phone number" password="bplmmsc" authtype="1" type="default,supl" />
   <apn carrier="BPL MMS" mcc="404" mnc="21" apn="mizone" user="Mobile phone number" password="bplmmsc" mmsc="http://mms.bplmobile.com:8080" mmsproxy="10.0.0.10" mmsport="8080" authtype="1" type="mms" />
@@ -1934,9 +1838,6 @@
   <apn carrier="Aircel Online" mcc="404" mnc="25" apn="aircelgprs" type="default,supl" />
   <apn carrier="Aircel GPRS" mcc="404" mnc="25" apn="aircelwap" proxy="172.17.83.69" port="8080" type="default,supl" />
   <apn carrier="Aircel MMS" mcc="404" mnc="25" apn="aircelmms" mmsc="http://172.17.83.67/servlets/mms/" mmsproxy="172.17.83.69" mmsport="8080" type="mms" />
-  <apn carrier="Vodafone" mcc="404" mnc="27" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="27" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="27" apn="www" type="default,supl" />
   <apn carrier="Aircel Online" mcc="404" mnc="28" apn="aircelgprs" type="default,supl" />
   <apn carrier="Aircel GPRS" mcc="404" mnc="28" apn="aircelwap" proxy="172.17.83.69" port="8080" type="default,supl" />
   <apn carrier="Aircel MMS" mcc="404" mnc="28" apn="aircelmms" mmsc="http://172.17.83.67/servlets/mms/" mmsproxy="172.17.83.69" mmsport="8080" type="mms" />
@@ -1945,12 +1846,6 @@
   <apn carrier="Aircel GPRS" mcc="404" mnc="29" apn="aircelwap" proxy="172.17.83.69" port="8080" type="default,supl" />
   <apn carrier="Aircel MMS" mcc="404" mnc="29" apn="aircelmms" mmsc="http://172.17.83.67/servlets/mms/" mmsproxy="172.17.83.69" mmsport="8080" type="mms" />
   <apn carrier="Aircel" mcc="404" mnc="29" apn="aircelwap" type="default,supl" />
-  <apn carrier="Vodafone" mcc="404" mnc="30" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="30" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="30" apn="www" type="default,supl" />
-  <apn carrier="Airtel GPRS" mcc="404" mnc="31" apn="airtelgprs.com" type="default,supl" />
-  <apn carrier="Airtel Live" mcc="404" mnc="31" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
-  <apn carrier="Airtel MMS" mcc="404" mnc="31" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Aircel" mcc="404" mnc="33" apn="aircelwap" type="default,supl" />
   <apn carrier="Aircel Online" mcc="404" mnc="33" apn="aircelgprs" type="default,supl" />
   <apn carrier="Aircel GPRS" mcc="404" mnc="33" apn="aircelwap" proxy="172.17.83.69" port="8080" type="default,supl" />
@@ -1978,6 +1873,7 @@
   <apn carrier="BSNL" mcc="404" mnc="38" apn="bsnlnet" user="MSISDN" password="MSISDN" type="default,supl" />
   <apn carrier="BSNL MMS" mcc="404" mnc="38" apn="mmssouth.cellone.in" user="MSISDN" password="mmsc" mmsc="http://10.7.236.11:8514" mmsproxy="10.7.236.11" mmsport="8080" type="mms" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="40" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="40" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="40" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="40" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Aircel Online" mcc="404" mnc="41" apn="aircelgprs" type="default,supl" />
@@ -1988,23 +1884,11 @@
   <apn carrier="Aircel GPRS" mcc="404" mnc="42" apn="aircelwap" proxy="172.17.83.69" port="8080" type="default,supl" />
   <apn carrier="Aircel MMS" mcc="404" mnc="42" apn="aircelmms" mmsc="http://172.17.83.67/servlets/mms/" mmsproxy="172.17.83.69" mmsport="8080" type="mms" />
   <apn carrier="Aircel" mcc="404" mnc="42" apn="aircelwap" type="default,supl" />
-  <apn carrier="Vodafone" mcc="404" mnc="43" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="43" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="43" apn="www" type="default,supl" />
   <apn carrier="IDEA Internet" mcc="404" mnc="44" apn="internet" type="default,supl" />
   <apn carrier="IDEA Wap" mcc="404" mnc="44" apn="imis" proxy="10.4.42.15" port="8080" type="default,supl" />
   <apn carrier="IDEA MMS" mcc="404" mnc="44" apn="mmsc" mmsc="http://10.4.42.21:8002" mmsproxy="10.4.42.15" mmsport="8080" type="mms" />
   <apn carrier="SPICE" mcc="404" mnc="44" apn="spicegprs" type="default,supl" />
   <apn carrier="SPICE MMS" mcc="404" mnc="44" apn="spicemms" user="User Mobile number" password="spice" mmsc="http://10.200.200.3:8514" mmsproxy="10.200.200.3" mmsport="8080" type="mms" />
-  <apn carrier="Airtel GPRS" mcc="404" mnc="45" apn="airtelgprs.com" type="default,supl" />
-  <apn carrier="Airtel Live" mcc="404" mnc="45" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
-  <apn carrier="Airtel MMS" mcc="404" mnc="45" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
-  <apn carrier="Vodafone" mcc="404" mnc="46" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="BPL MMS" mcc="404" mnc="46" apn="mizone" user="MSISDN" password="bplmmsc" mmsc="http://mms.bplmobile.com:8080" mmsproxy="10.0.0.10" mmsport="8080" type="mms" />
-  <apn carrier="BPL" mcc="404" mnc="46" apn="www" user="MSISDN" password="bplmmsc" type="default,supl" />
-  <apn carrier="Airtel GPRS" mcc="404" mnc="49" apn="airtelgprs.com" type="default,supl" />
-  <apn carrier="Airtel Live" mcc="404" mnc="49" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
-  <apn carrier="Airtel MMS" mcc="404" mnc="49" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="NetConnect" mcc="404" mnc="50" apn="rcomnet" type="default,supl" />
   <apn carrier="Reliance GPRS" mcc="404" mnc="50" apn="rcomwap" proxy="10.239.221.5" port="8080" type="default,supl" />
   <apn carrier="Smart MMS" mcc="404" mnc="50" apn="rcommms" proxy="10.239.221.5" port="8080" mmsc="http://10.239.221.47/mms/" mmsproxy="10.239.221.5" mmsport="8080" type="mms" />
@@ -2052,10 +1936,8 @@
   <apn carrier="BSNL-mms" mcc="404" mnc="59" apn="bsnlmms" proxy="10.210.10.11" port="8080" mmsc="http://bsnlmmsc.in:8514" mmsproxy="10.210.10.11" mmsport="8080" type="mms" />
   <apn carrier="BSNL" mcc="404" mnc="59" apn="bsnlnet" user="MSISDN" password="MSISDN" type="default,supl" />
   <apn carrier="BSNL MMS" mcc="404" mnc="59" apn="mmssouth.cellone.in" user="MSISDN" password="mmsc" mmsc="http://10.7.236.11:8514" mmsproxy="10.7.236.11" mmsport="8080" type="mms" />
-  <apn carrier="Vodafone" mcc="404" mnc="60" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="60" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="60" apn="www" type="default,supl" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="61" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="61" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="61" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="61" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.001.201.172" mmsport="8799" authtype="1" type="mms" />
   <apn carrier="BSNL NET" mcc="404" mnc="62" apn="bsnlnet" type="default,supl" />
@@ -2091,6 +1973,7 @@
   <apn carrier="MTNL" mcc="404" mnc="69" apn="mtnl.net" proxy="10.10.10.10" port="9401" user="mtnl" password="mtnl123" type="default,supl" />
   <apn carrier="MTNL MMS" mcc="404" mnc="69" apn="mtnl.net" user="mtnl" password="mtnl123" mmsc="http://mtnlmms/" mmsproxy="10.10.10.10" mmsport="9401" type="mms" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="70" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="70" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="70" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="70" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="BSNL NET" mcc="404" mnc="71" apn="bsnlnet" type="default,supl" />
@@ -2153,28 +2036,20 @@
   <apn carrier="Reliance GPRS" mcc="404" mnc="83" apn="rcomwap" proxy="10.239.221.5" port="8080" type="default,supl" />
   <apn carrier="Smart MMS" mcc="404" mnc="83" apn="rcommms" proxy="10.239.221.5" port="8080" mmsc="http://10.239.221.47/mms/" mmsproxy="10.239.221.5" mmsport="8080" type="mms" />
   <apn carrier="Reliance MMS" mcc="404" mnc="83" apn="rcommms" proxy="10.239.221.5" port="8080" mmsc="http://mms.rcom.co.in/mms" mmsproxy="10.239.221.5" mmsport="8080" type="mms" />
-  <apn carrier="Vodafone" mcc="404" mnc="84" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="84" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="84" apn="www" type="default,supl" />
   <apn carrier="NetConnect" mcc="404" mnc="85" apn="rcomnet" type="default,supl" />
   <apn carrier="Reliance GPRS" mcc="404" mnc="85" apn="rcomwap" proxy="10.239.221.5" port="8080" type="default,supl" />
   <apn carrier="Smart MMS" mcc="404" mnc="85" apn="rcommms" proxy="10.239.221.5" port="8080" mmsc="http://10.239.221.47/mms/" mmsproxy="10.239.221.5" mmsport="8080" type="mms" />
   <apn carrier="Reliance MMS" mcc="404" mnc="85" apn="rcommms" proxy="10.239.221.5" port="8080" mmsc="http://mms.rcom.co.in/mms" mmsproxy="10.239.221.5" mmsport="8080" type="mms" />
-  <apn carrier="Vodafone" mcc="404" mnc="86" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="86" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="86" apn="www" type="default,supl" />
   <apn carrier="IDEA Internet" mcc="404" mnc="87" apn="internet" type="default,supl" />
   <apn carrier="IDEA Wap" mcc="404" mnc="87" apn="imis" proxy="10.4.42.15" port="8080" type="default,supl" />
   <apn carrier="IDEA MMS" mcc="404" mnc="87" apn="mmsc" mmsc="http://10.4.42.21:8002" mmsproxy="10.4.42.15" mmsport="8080" type="mms" />
   <apn carrier="IDEA Mobile" mcc="404" mnc="87" apn="mobile" type="default,supl" />
-  <apn carrier="Vodafone" mcc="404" mnc="88" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="404" mnc="88" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="404" mnc="88" apn="www" type="default,supl" />
   <apn carrier="IDEA Internet" mcc="404" mnc="89" apn="internet" type="default,supl" />
   <apn carrier="IDEA Wap" mcc="404" mnc="89" apn="imis" proxy="10.4.42.15" port="8080" type="default,supl" />
   <apn carrier="IDEA MMS" mcc="404" mnc="89" apn="mmsc" mmsc="http://10.4.42.21:8002" mmsproxy="10.4.42.15" mmsport="8080" type="mms" />
   <apn carrier="IDEA Mobile" mcc="404" mnc="89" apn="mobile" type="default,supl" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="90" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="90" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="90" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="90" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Aircel Online" mcc="404" mnc="91" apn="aircelgprs" type="default,supl" />
@@ -2184,25 +2059,29 @@
   <apn carrier="Aircel" mcc="404" mnc="91" apn="aircelgprs" type="default,supl" />
   <apn carrier="Aircel MMS" mcc="404" mnc="91" apn="aircelmms" proxy="172.17.83.69" port="8080" mmsc="http://172.17.83.67//servlets/mms" mmsproxy="172.17.83.69" mmsport="8080" type="mms" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="92" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="92" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="92" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="92" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="93" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="93" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="93" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="93" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="94" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="94" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="94" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="94" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="95" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="95" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="95" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="95" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Airtel GPRS" mcc="404" mnc="96" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="96" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="96" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="96" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
+  <apn carrier="Airtel GPRS" mcc="404" mnc="97" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="404" mnc="97" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="404" mnc="97" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="404" mnc="97" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
-  <apn carrier="Airtel GPRS" mcc="404" mnc="98" apn="airtelgprs.com" type="default,supl" />
-  <apn carrier="Airtel Live" mcc="404" mnc="98" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
-  <apn carrier="Airtel MMS" mcc="404" mnc="98" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="NetConnect" mcc="405" mnc="01" apn="rcomnet" type="default,supl" />
   <apn carrier="Reliance GPRS" mcc="405" mnc="01" apn="rcomwap" proxy="10.239.221.5" port="8080" type="default,supl" />
   <apn carrier="Smart MMS" mcc="405" mnc="01" apn="rcommms" proxy="10.239.221.5" port="8080" mmsc="http://10.239.221.47/mms/" mmsproxy="10.239.221.5" mmsport="8080" type="mms" />
@@ -2426,61 +2305,41 @@
   <apn carrier="Smart MMS" mcc="405" mnc="23" apn="rcommms" proxy="10.239.221.5" port="8080" mmsc="http://10.239.221.47/mms/" mmsproxy="10.239.221.5" mmsport="8080" type="mms" />
   <apn carrier="Reliance MMS" mcc="405" mnc="23" apn="rcommms" proxy="10.239.221.5" port="8080" mmsc="http://mms.rcom.co.in/mms" mmsproxy="10.239.221.5" mmsport="8080" type="mms" />
   <apn carrier="Airtel GPRS" mcc="405" mnc="51" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="405" mnc="51" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="405" mnc="51" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="405" mnc="51" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Airtel MMS" mcc="405" mnc="51" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" authtype="1" type="mms" />
   <apn carrier="Airtel GPRS" mcc="405" mnc="52" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="405" mnc="52" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="405" mnc="52" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="405" mnc="52" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Airtel MMS" mcc="405" mnc="52" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" authtype="1" type="mms" />
   <apn carrier="Airtel GPRS" mcc="405" mnc="53" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="405" mnc="53" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="405" mnc="53" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="405" mnc="53" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Airtel MMS" mcc="405" mnc="53" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" authtype="1" type="mms" />
   <apn carrier="Airtel GPRS" mcc="405" mnc="54" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="405" mnc="54" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="405" mnc="54" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="405" mnc="54" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Airtel MMS" mcc="405" mnc="54" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" authtype="1" type="mms" />
   <apn carrier="Airtel GPRS" mcc="405" mnc="55" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="405" mnc="55" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="405" mnc="55" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="405" mnc="55" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Airtel MMS" mcc="405" mnc="55" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" authtype="1" type="mms" />
   <apn carrier="Airtel GPRS" mcc="405" mnc="56" apn="airtelgprs.com" type="default,supl" />
+  <apn carrier="Airtel IMS" mcc="405" mnc="56" apn="ims" type="ims" protocol="IPV4V6" />
   <apn carrier="Airtel Live" mcc="405" mnc="56" apn="airtelfun.com" proxy="100.1.200.99" port="8080" type="default,supl" />
   <apn carrier="Airtel MMS" mcc="405" mnc="56" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" />
   <apn carrier="Airtel MMS" mcc="405" mnc="56" apn="airtelmms.com" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" authtype="1" type="mms" />
-  <apn carrier="Vodafone" mcc="405" mnc="66" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="405" mnc="66" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="405" mnc="66" apn="www" type="default,supl" />
-  <apn carrier="Vodafone" mcc="405" mnc="67" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="405" mnc="67" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="405" mnc="67" apn="www" type="default,supl" />
   <apn carrier="IDEA Internet" mcc="405" mnc="70" apn="internet" type="default,supl" />
   <apn carrier="IDEA Wap" mcc="405" mnc="70" apn="imis" proxy="10.4.42.15" port="8080" type="default,supl" />
   <apn carrier="IDEA MMS" mcc="405" mnc="70" apn="mmsc" mmsc="http://10.4.42.21:8002" mmsproxy="10.4.42.15" mmsport="8080" type="mms" />
   <apn carrier="IDEA Mobile" mcc="405" mnc="70" apn="mobile" type="default,supl" />
   <apn carrier="IDEA" mcc="405" mnc="70" apn="internet" type="default,supl" />
   <apn carrier="IDEA MMS" mcc="405" mnc="70" apn="mmsc" mmsc="http://10.4.42.21:8002/" mmsproxy="10.4.42.15" mmsport="8080" type="mms" />
-  <apn carrier="Vodafone" mcc="405" mnc="750" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="405" mnc="750" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="405" mnc="750" apn="www" type="default,supl" />
-  <apn carrier="Vodafone" mcc="405" mnc="751" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN" mcc="405" mnc="751" apn="www" type="default,supl" />
-  <apn carrier="Vodafone" mcc="405" mnc="752" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="405" mnc="752" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="405" mnc="752" apn="www" type="default,supl" />
-  <apn carrier="Vodafone" mcc="405" mnc="753" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="405" mnc="753" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="405" mnc="753" apn="www" type="default,supl" />
-  <apn carrier="Vodafone" mcc="405" mnc="754" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="405" mnc="754" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="405" mnc="754" apn="www" type="default,supl" />
-  <apn carrier="Vodafone" mcc="405" mnc="755" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="405" mnc="755" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="405" mnc="755" apn="www" type="default,supl" />
-  <apn carrier="Vodafone" mcc="405" mnc="756" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="default,supl,mms" />
-  <apn carrier="Vodafone IN MMS" mcc="405" mnc="756" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" mmsport="9401" type="mms" />
-  <apn carrier="Vodafone IN" mcc="405" mnc="756" apn="www" type="default,supl" />
   <apn carrier="IDEA Internet" mcc="405" mnc="799" apn="internet" type="default,supl" />
   <apn carrier="IDEA Wap" mcc="405" mnc="799" apn="imis" proxy="10.4.42.15" port="8080" type="default,supl" />
   <apn carrier="IDEA MMS" mcc="405" mnc="799" apn="mmsc" mmsc="http://10.4.42.21:8002" mmsproxy="10.4.42.15" mmsport="8080" type="mms" />
@@ -2824,11 +2683,6 @@
   <apn carrier="Qtel mms" apn="mms.qtel" mmsc="http://mmsr.qtelmms.qa" mmsproxy="10.23.8.3" mmsport="8080" mcc="427" mnc="01" type="mms" />
   <apn carrier="Q-tel MMS" mcc="427" mnc="01" apn="mms.qtel" user="mms" password="gprs" mmsc="http://mmsr.qtelmma.qa" mmsproxy="10.23.8.3" mmsport="9201" type="mms" />
   <apn carrier="Q-tel" mcc="427" mnc="01" apn="web.qtel" user="gprs" password="gprs" type="default,supl" />
-  <apn carrier="VFQ MMS" mcc="427" mnc="02" apn="vodafone.com.qa" proxy="10.101.97.102" port="80" mmsc="http://mms.vodafone.com.qa/mmsc" mmsproxy="10.101.97.102" mmsport="80" authtype="1" type="*" />
-  <apn carrier="VFQ Internet" mcc="427" mnc="02" apn="web.vodafone.com.qa" authtype="1" type="default,supl" />
-  <apn carrier="WAP" mcc="427" mnc="02" apn="vodafone.com.qa" proxy="10.101.97.102" port="80" type="default,supl" />
-  <apn carrier="Vodafone QA MMS" mcc="427" mnc="02" apn="vodafone.com.qa" mmsc="http://mms.vodafone.com.qa/mmsc" mmsproxy="10.101.97.102" mmsport="80" type="mms" />
-  <apn carrier="Vodafone QA" mcc="427" mnc="02" apn="web.vodafone.com.qa" type="default,supl" />
   <apn carrier="GPRS APN" mcc="429" mnc="01" apn="ntwap" proxy="192.80.7.133" port="8000" mmsc="" user="" password="" type="default,supl" />
   <apn carrier="WEB" mcc="429" mnc="01" apn="ntnet" user="" password="" type="default,supl" />
   <apn carrier="MMS" mcc="429" mnc="01" apn="ntmms" proxy="" port="" mmsproxy="192.80.7.133" mmsport="8000" mmsc="http://192.80.11.180" user="" password="" type="mms" />
@@ -2840,9 +2694,9 @@
   <apn carrier="Ncell Internet" mcc="429" mnc="02" apn="web" type="default,supl" />
   <apn carrier="Ncell MMS" mcc="429" mnc="02" apn="mms" mmsc="http://192.168.19.15" mmsproxy="192.168.19.15" mmsport="8080" type="mms" />
   <apn carrier="Ncell WAP" mcc="429" mnc="02" apn="web" proxy="192.168.19.15" port="8080" type="default,supl" />
-  <apn carrier="Rightel" mcc="432" mnc="20" apn="rightel"  type="default,supl" />
+  <apn carrier="Rightel" mcc="432" mnc="20" apn="rightel" type="default,supl" />
   <apn carrier="Rightel MMS" mcc="432" mnc="20" apn="RighTel-WAP" mmsc="http://10.200.40.55:38090/was" mmsproxy="10.200.39.10" mmsport="8080" type="mms" />
-  <apn carrier="IR-MCI" mcc="432" mnc="11" apn="mcinet"  type="default,supl" />
+  <apn carrier="IR-MCI" mcc="432" mnc="11" apn="mcinet" type="default,supl" />
   <apn carrier="IR-MCI MMS" mcc="432" mnc="20" apn="mcinet" mmsc="http://192.168.193.134:38090/was" mmsproxy="192.168.194.73" mmsport="8080" type="mms" />
   <apn carrier="Irancell" mcc="432" mnc="35" apn="irancell" type="default,supl" />
   <apn carrier="Irancell MMS" mcc="432" mnc="35" apn="irancell" mmsc="http://mms:8002" mmsproxy="10.131.26.138" mmsport="8080" type="mms" />
@@ -2853,7 +2707,7 @@
   <apn carrier="Perfectum" mcc="434" mnc="06" apn="default" user="perfectum@perfectum.com" password="a" type="default,supl" />
   <apn carrier="MTS Internet" mcc="434" mnc="07" apn="net.mts.uz" user="mts" password="mts" authtype="1" type="default,supl" />
   <apn carrier="MTS MMS" mcc="434" mnc="07" apn="mms.mts.uz" proxy="" port="" mmsproxy="10.10.0.10" mmsport="8080" mmsc="http://mmsc/was" user="mts" password="mts" authtype="1" type="mms" />
-  <apn carrier="em.std" mcc="440" mnc="00" apn="em.std" user="em" password="em" type="default,supl" bearer="14"/>
+  <apn carrier="em.std" mcc="440" mnc="00" apn="em.std" user="em" password="em" type="default,supl" bearer="14" />
   <apn carrier="@nifty do LTE" mcc="440" mnc="10" apn="lte.fenics.jp" user="nifty@lte.nifty.com" password="nifty" authtype="3" type="default,supl" />
   <apn carrier="AsahiNet 3G" mcc="440" mnc="10" apn="3g.mobac.net" user="d@w3.asahinet.jp" password="0000" authtype="3" type="default,supl" />
   <apn carrier="AsahiNet 3G 128K" mcc="440" mnc="10" apn="3g.mobac.net" user="d@x3.asahinet.jp" password="0000" authtype="3" type="default,supl" />
@@ -3045,35 +2899,6 @@
   <apn carrier="Beeline Internet" mcc="456" mnc="09" apn="gprs.beeline.com.kh" type="default,supl" />
   <apn carrier="Beeline MMS" mcc="456" mnc="09" apn="mms.beeline.com.kh" mmsc="http://mms.qbmore.mobi" mmsproxy="10.18.34.135" mmsport="8080" type="mms" />
   <apn carrier="Camshin" mcc="456" mnc="18" apn="Camshin" mmsc="http://172.16.205.10:38090" mmsproxy="172.16.203.85" mmsport="8080" type="default,mms" />
-  <apn carrier="中国移动因特网设置" mcc="460" mnc="00" apn="cmnet" user="" password="" authtype="3" type="default,supl" />
-  <apn carrier="中国移动WAP设置" mcc="460" mnc="00" apn="cmwap" proxy="10.0.0.172" port="80" mmsc="" user="" password="" authtype="3" type="default,supl" />
-  <apn carrier="中国移动彩信设置" mcc="460" mnc="00" apn="cmwap" proxy="" port="" mmsproxy="10.0.0.172" mmsport="80" mmsc="http://mmsc.monternet.com" user="" password="" authtype="3" type="mms" />
-  <apn carrier="中国移动 GPRS (China Mobile)" mcc="460" mnc="00" apn="cmnet" type="default,supl" />
-  <apn carrier="中国移动 Wap 网络 (China Mobile)" mcc="460" mnc="00" apn="cmwap" proxy="10.0.0.172" port="80" />
-  <apn carrier="中国移动彩信 (China Mobile)" mcc="460" mnc="00" apn="cmwap" proxy="10.0.0.172" port="80" mmsc="http://mmsc.monternet.com" mmsproxy="10.0.0.172" mmsport="80" type="mms" />
-  <apn carrier="China Mobile" mcc="460" mnc="00" apn="cmnet" type="default,supl" />
-  <apn carrier="China Mobile MMS" mcc="460" mnc="00" apn="cmwap" proxy="10.0.0.172" port="80" mmsc="http://mmsc.monternet.com" mmsproxy="10.0.0.172" mmsport="80" type="mms" />
-  <apn carrier="中国联通 3g 网络 (China Unicom)" mcc="460" mnc="01" apn="3gnet" type="default,supl" />
-  <apn carrier="中国联通 GPRS (China Unicom)" mcc="460" mnc="01" apn="uninet" type="default,supl" />
-  <apn carrier="中国联通 Wap 网络 (China Unicom)" mcc="460" mnc="01" apn="3gwap" proxy="10.0.0.172" port="80" />
-  <apn carrier="中国联通 Wap 网络 (China Unicom)" mcc="460" mnc="01" apn="uniwap" proxy="10.0.0.172" port="80" />
-  <apn carrier="中国联通 3g 彩信 (China Unicom)" mcc="460" mnc="01" apn="3gwap" mmsc="http://mmsc.myuni.com.cn" mmsproxy="10.0.0.172" mmsport="80" type="mms" />
-  <apn carrier="中国联通彩信 (China Unicom)" mcc="460" mnc="01" apn="uniwap" mmsc="http://mmsc.myuni.com.cn" mmsproxy="10.0.0.172" mmsport="80" type="mms" />
-  <apn carrier="中国联通3g因特网设置" mcc="460" mnc="01" apn="3gnet" proxy="" port="" mmsc="" user="" password="" authtype="3" type="default,supl" />
-  <apn carrier="中国联通3gwap设置" mcc="460" mnc="01" apn="3gwap" proxy="10.0.0.172" port="80" mmsc="" user="" password="" authtype="3" type="default,supl" />
-  <apn carrier="中国联通3g彩信设置" mcc="460" mnc="01" apn="3gwap" proxy="" port="" mmsc="http://mmsc.myuni.com.cn" mmsproxy="10.0.0.172" mmsport="80" user="" password="" authtype="3" type="mms" />
-  <apn carrier="China Unicom 3G" mcc="460" mnc="01" apn="3gnet" port="80" type="default,supl" />
-  <apn carrier="China Unicom MMS" mcc="460" mnc="01" apn="uniwap" mmsc="http://mmsc.myuni.com.cn" mmsproxy="10.0.0.172" mmsport="80" type="mms" />
-  <apn carrier="中国移动因特网设置" mcc="460" mnc="02" apn="cmnet" user="" password="" authtype="3" type="default,supl" />
-  <apn carrier="中国移动WAP设置" mcc="460" mnc="02" apn="cmwap" proxy="10.0.0.172" port="80" mmsc="" user="" password="" authtype="3" type="default,supl" />
-  <apn carrier="中国移动彩信设置" mcc="460" mnc="02" apn="cmwap" proxy="" port="" mmsproxy="10.0.0.172" mmsport="80" mmsc="http://mmsc.monternet.com" user="" password="" authtype="3" type="mms" />
-  <apn carrier="中国移动 GPRS (China Mobile)" mcc="460" mnc="02" apn="cmnet" type="default,supl" />
-  <apn carrier="中国移动 Wap 网络 (China Mobile)" mcc="460" mnc="02" apn="cmwap" proxy="10.0.0.172" port="80" />
-  <apn carrier="中国移动彩信 (China Mobile)" mcc="460" mnc="02" apn="cmwap" proxy="10.0.0.172" port="80" mmsc="http://mmsc.monternet.com" mmsproxy="10.0.0.172" mmsport="80" type="mms" />
-  <apn carrier="China Mobile" mcc="460" mnc="02" apn="cmnet" type="default,supl" />
-  <apn carrier="China Mobile MMS" mcc="460" mnc="02" apn="cmwap" proxy="10.0.0.172" port="80" mmsc="http://mmsc.monternet.com" mmsproxy="10.0.0.172" mmsport="80" type="mms" />
-  <apn carrier="China Mobile" mcc="460" mnc="02" apn="cmnet" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="China Mobile MMS" mcc="460" mnc="02" apn="cmwap" proxy="10.0.0.172" port="80" user="" password="" mmsc="http://mmsc.monternet.com" mmsproxy="10.0.0.172" mmsport="80" type="mms" />
   <apn carrier="中国电信互联网设置CTNET" mcc="460" mnc="03" apn="ctnet" proxy="" port="" user="ctnet@mycdma.cn" password="vnet.mobi" mmsc="" authtype="3" type="default,supl" />
   <apn carrier="中国电信WAP设置CTWAP" mcc="460" mnc="03" apn="ctwap" proxy="10.0.0.200" port="80" user="ctwap@mycdma.cn" password="vnet.mobi" mmsc="http://mmsc.vnet.mobi" mmsproxy="10.0.0.200" mmsport="80" authtype="2" type="default,mms,supl" />
   <apn carrier="China Telecom" apn="ctlte" mcc="460" mnc="03" user="" password="" protocol="IPV4V6" roaming_protocol="IPV4V6" type="ia" />
@@ -3089,12 +2914,8 @@
   <apn carrier="中国联通 Wap 网络 (China Unicom)" mcc="460" mnc="09" apn="uniwap" proxy="10.0.0.172" port="80" />
   <apn carrier="中国联通 3g 彩信 (China Unicom)" mcc="460" mnc="09" apn="3gwap" mmsc="http://mmsc.myuni.com.cn" mmsproxy="10.0.0.172" mmsport="80" type="mms" />
   <apn carrier="中国联通彩信 (China Unicom)" mcc="460" mnc="09" apn="uniwap" mmsc="http://mmsc.myuni.com.cn" mmsproxy="10.0.0.172" mmsport="80" type="mms" />
-  <apn carrier="China Unicom 3G" mcc="460" mnc="09" apn="3gnet" port="80" type="default,supl"/>
+  <apn carrier="China Unicom 3G" mcc="460" mnc="09" apn="3gnet" port="80" type="default,supl" />
   <apn carrier="China Unicom wap" mcc="460" mnc="09" apn="3gwap" proxy="10.0.0.172" port="80" mmsproxy="10.0.0.172" mmsport="80" mmsc="http://mmsc.myuni.com.cn" type="default, mms" />
-  <apn carrier="中国电信互联网设置CTLTE" mcc="460" mnc="11" apn="ctlte" proxy="" port="" user="ctlte@mycdma.cn" password="vnet.mobi" mmsc="" authtype="3" type="default,supl" />
-  <apn carrier="中国电信互联网设置CTNET" mcc="460" mnc="11" apn="ctnet" proxy="" port="" user="ctnet@mycdma.cn" password="vnet.mobi" mmsc="" authtype="3" type="default,supl" />
-  <apn carrier="中国电信WAP设置CTWAP" mcc="460" mnc="11" apn="ctwap" proxy="10.0.0.200" port="80" user="ctwap@mycdma.cn" password="vnet.mobi" mmsc="http://mmsc.vnet.mobi" mmsproxy="10.0.0.200" mmsport="80" authtype="2" type="default,mms,supl" />
-  <apn carrier="China Telecom" apn="ctlte" mcc="460" mnc="11" user="" password="" protocol="IPV4V6" roaming_protocol="IPV4V6" type="ia" />
   <apn carrier="中国电信互联网设置CTNET" mcc="460" mnc="12" apn="ctnet" proxy="" port="" user="ctnet@mycdma.cn" password="vnet.mobi" mmsc="" authtype="3" type="default,supl" />
   <apn carrier="中国电信WAP设置CTWAP" mcc="460" mnc="12" apn="ctwap" proxy="10.0.0.200" port="80" user="ctwap@mycdma.cn" password="vnet.mobi" mmsc="http://mmsc.vnet.mobi" mmsproxy="10.0.0.200" mmsport="80" authtype="2" type="default,mms,supl" />
   <apn carrier="中国电信互联网设置CTNET" mcc="460" mnc="13" apn="ctnet" user="ctnet@mycdma.cn" password="vnet.mobi" authtype="3" type="default,supl,dun" />
@@ -3205,13 +3026,10 @@
   <apn carrier="Virgin AU MMS" mcc="505" mnc="02" apn="virginmms" user="*" password="*" server="*" proxy="202.139.083.152" port="8070" mmsc="http://mms.virginvibe.com.au:8002/" mmsproxy="202.139.083.152" mmsport="8070" type="mms" />
   <apn carrier="Optus Internet" mcc="505" mnc="02" apn="yesinternet" user="*" password="*" server="*" type="default,supl" />
   <apn carrier="Apex Telecom" mcc="505" mnc="02" apn="splns357" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Boost MMS" mcc="505" mnc="02" apn="mms" user="" password="" proxy="61.88.190.10" port="8070" mmsc="http://mmsc.optus.com.au:8002/" mmsproxy="61.88.190.10" mmsport="8070" type="mms" authtype="3"/>
-  <apn carrier="Boost Mobile" mcc="505" mnc="02" apn="yesinternet" user="" password="" proxy="" port="" mmsc="" type="default,supl" authtype="3"/>
+  <apn carrier="Boost MMS" mcc="505" mnc="02" apn="mms" user="" password="" proxy="61.88.190.10" port="8070" mmsc="http://mmsc.optus.com.au:8002/" mmsproxy="61.88.190.10" mmsport="8070" type="mms" authtype="3" />
+  <apn carrier="Boost Mobile" mcc="505" mnc="02" apn="yesinternet" user="" password="" proxy="" port="" mmsc="" type="default,supl" authtype="3" />
   <apn carrier="Truphone" mcc="505" mnc="02" apn="truphone.com" type="default,dun" mvno_match_data="50502100" mvno_type="imsi" />
-  <apn carrier="Vodafone Live!" mcc="505" mnc="03" apn="live.vodafone.com" proxy="10.202.2.60" port="8080" mmsc="" user="" password="" type="default,supl" />
-  <apn carrier="Vodafone PXT" mcc="505" mnc="03" apn="live.vodafone.com" proxy="" port="" mmsproxy="10.202.2.60" mmsport="8080" mmsc="http://pxt.vodafone.net.au/pxtsend" user="" password="" type="mms" />
-  <apn carrier="Vodafone AU" mcc="505" mnc="03" apn="live.vodafone.com" user="*" password="*" server="*" mmsc="http://pxt.vodafone.net.au/pxtsend" mmsproxy="10.202.2.60" mmsport="8080" type="mms,default,supl" />
-  <apn carrier="3 AU" mcc="505" mnc="06" apn="3services" mmsc="http://mmsc.three.net.au:10021/mmsc" mmsproxy="10.176.57.25" mmsport="8799" type="default,supl,mms"/>
+  <apn carrier="3 AU" mcc="505" mnc="06" apn="3services" mmsc="http://mmsc.three.net.au:10021/mmsc" mmsproxy="10.176.57.25" mmsport="8799" type="default,supl,mms" />
   <apn carrier="VF AU PXT" mcc="505" mnc="07" apn="live.vodafone.com" mmsc="http://pxt.vodafone.net.au/pxtsend" mmsproxy="10.202.2.60" mmsport="8080" type="mms" />
   <apn carrier="VF Internet" mcc="505" mnc="07" apn="vfinternet.au" type="default,supl" />
   <apn carrier="Telstra MMS" mcc="505" mnc="11" apn="Telstra.mms" mmsc="http://mmsc.telstra.com:8002" mmsproxy="10.1.1.180" mmsport="80" type="mms" />
@@ -3238,16 +3056,8 @@
   <apn carrier="AXIS MMS" mcc="510" mnc="08" apn="axismms" mmsproxy="10.8.3.8" mmsport="8080" mmsc="http://mmsc.axis" user="axis" password="123456" authtype="1" type="mms" />
   <apn carrier="AXIS" mcc="510" mnc="08" apn="AXIS" user="axis" password="123456" type="default,supl" />
   <apn carrier="AXIS MMS" mcc="510" mnc="08" apn="AXISmms" user="axis" password="123456" mmsc="http://mmsc.AXIS" mmsproxy="10.8.3.8" mmsport="8080" type="mms" />
-  <apn carrier="Smartfren4G" mcc="510" mnc="09" apn="Smartfren4G" user="smartfren" password="smartfren" authtype="3" type="default,supl" protocol="IPV4V6" />
-  <apn carrier="Smartfren MMS" mcc="510" mnc="09" apn="smartfren" user="smartfren" password="smartfren" mmsc="http://10.17.93.103:8080" mmsproxy="10.17.27.250" mmsport="8080" authtype="3" type="mms" protocol="IPV4V6" />
-  <apn carrier="Smartfren IMS" mcc="510" mnc="09" apn="IMS" type="ims" />
   <apn carrier="AXIS" mcc="510" mnc="08" apn="AXIS" proxy="" port="" user="axis" password="123456" mmsc="" type="default,supl" />
   <apn carrier="AXIS MMS" mcc="510" mnc="08" apn="AXISmms" proxy="" port="" user="axis" password="123456" mmsc="http://mmsc.AXIS" mmsproxy="10.8.3.8" mmsport="8080" type="mms" />
-  <apn carrier="TSEL BROADBAND" mcc="510" mnc="10" apn="internet" proxy="" port="" user="wap" password="wap123" authtype="1" type="default,supl" />
-  <apn carrier="TSEL TIMEBASED" mcc="510" mnc="10" apn="flash" proxy="" port="" user="wap" password="wap123" authtype="1" type="default,supl" />
-  <apn carrier="TSEL MMS" mcc="510" mnc="10" apn="mms" mmsproxy="10.1.89.150" mmsport="8000" mmsc="http://mms.telkomsel.com" user="wap" password="wap123" authtype="1" type="mms" />
-  <apn carrier="Telkomsel" mcc="510" mnc="10" apn="internet" type="default,supl" />
-  <apn carrier="Telkomsel MMS" mcc="510" mnc="10" apn="mms" user="wap" password="wap123" mmsc="http://mms.telkomsel.com" mmsproxy="10.1.89.150" mmsport="9201" type="mms" />
   <apn carrier="XL Unlimited" mcc="510" mnc="11" apn="xlunlimited" proxy="202.152.240.50" port="8080" mmsc="" user="" password="" type="default,supl" />
   <apn carrier="XL-GPRS" mcc="510" mnc="11" apn="www.xlgprs.net" proxy="202.152.240.50" port="8080" mmsc="" user="xlgprs" password="proxl" type="default,supl" />
   <apn carrier="XL-MMS" mcc="510" mnc="11" apn="www.xlmms.net" proxy="" port="" mmsproxy="202.152.240.50" mmsport="8080" mmsc="http://mmc.xl.net.id/servlets/mms" user="xlgprs" password="proxl" type="mms" />
@@ -3271,7 +3081,7 @@
   <apn carrier="myGlobe MMS" mcc="515" mnc="02" apn="mms.globe.com.ph" mmsc="http://192.40.100.22:10021/mmsc" mmsproxy="203.177.42.214" mmsport="8080" type="mms" />
   <apn carrier="SMART Internet postpaid" mcc="515" mnc="03" apn="internet" authtype="1" type="default" />
   <apn carrier="SMART HTTP postpaid" mcc="515" mnc="03" apn="smart1" proxy="10.102.61.46" port="9201" user="smartwap" password="smartwap" authtype="1" type="default" />
-  <apn carrier="SMART(3G) Internet postpaid" mcc="515" mnc="03" apn="internet" type="default,supl"/>
+  <apn carrier="SMART(3G) Internet postpaid" mcc="515" mnc="03" apn="internet" type="default,supl" />
   <apn carrier="SMART(3G) MMS postpaid" mcc="515" mnc="03" apn="mms" mmsc="http://10.102.61.238:8002" mmsproxy="10.102.61.46" mmsport="8080" type="mms" />
   <apn carrier="SMART(3G) Internet prepaid" mcc="515" mnc="03" apn="internet" type="default,supl" />
   <apn carrier="SMART(3G) HTTP prepaid" mcc="515" mnc="03" apn="smart1" proxy="10.102.61.46" port="80" user="smartwap" password="smartwap" authtype="1" type="default" />
@@ -3297,17 +3107,23 @@
   <apn carrier="DTAC GPRS WEB" mcc="520" mnc="18" apn="www.dtac.co.th" type="default,supl" />
   <apn carrier="True" mcc="520" mnc="99" apn="internet" user="true" password="true" type="default,supl" />
   <apn carrier="True MMS" mcc="520" mnc="99" apn="mms" user="true" password="true" mmsc="http://mms.trueworld.net:8002" mmsproxy="10.4.7.39" mmsport="8080" type="mms" />
-  <apn carrier="SingTel (PostPaid)" mcc="525" mnc="01" apn="e-ideas" mmsproxy="165.21.42.84" mmsport="8080" mmsc="http://mms.singtel.com:10021/mmsc" type="default,supl,mms" />
-  <apn carrier="SingTel (PrePaid)" mcc="525" mnc="01" apn="hicard" mmsproxy="165.21.42.84" mmsport="8080" mmsc="http://mms.singtel.com:10021/mmsc" type="default,supl,mms" />
-  <apn carrier="SingTel (PostPaid)" mcc="525" mnc="02" apn="e-ideas" mmsproxy="165.21.42.84" mmsport="8080" mmsc="http://mms.singtel.com:10021/mmsc" type="default,supl,mms" />
-  <apn carrier="SingTel (PrePaid)" mcc="525" mnc="02" apn="hicard" mmsproxy="165.21.42.84" mmsport="8080" mmsc="http://mms.singtel.com:10021/mmsc" type="default,supl,mms" />
-  <apn carrier="Sunsurf Mobile" mcc="525" mnc="03" apn="sunsurf" type="default,supl" />
-  <apn carrier="M1 MMS(3G)" mcc="525" mnc="03" apn="miworld" user="65" password="user123" mmsc="http://mmsgw:8002" mmsproxy="172.16.14.10" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="Sunsurf Mobile" mcc="525" mnc="04" apn="sunsurf" type="default,supl" />
-  <apn carrier="M1 MMS(3G)" mcc="525" mnc="04" apn="miworld" user="65" password="user123" authtype="1" mmsc="http://mmsgw:8002" mmsproxy="172.16.14.10" mmsport="8080" type="mms" />
-  <apn carrier="SH Data Postpaid" mcc="525" mnc="05" apn="shwap" type="default,supl" />
-  <apn carrier="SH Data Prepaid" mcc="525" mnc="05" apn="shppd" type="default,supl" />
-  <apn carrier="SH MMS Postpaid" mcc="525" mnc="05" apn="shmms" mmsc="http://mms.starhubgee.com.sg:8002/" mmsproxy="10.12.1.80" mmsport="80" type="mms" />
+  <apn carrier="SingTel" mcc="525" mnc="01" apn="e-ideas" type="default,supl" />
+  <apn carrier="SingTel hi!card" mcc="525" mnc="01" apn="hicard" mmsc="http://mms.singtel.com:10021/mmsc" mmsproxy="165.21.42.84" mmsport="8080" authtype="1" type="default,supl,mms" />
+  <apn carrier="IDEAS" mcc="525" mnc="01" apn="e-ideas" type="default,supl,mms" />
+  <apn carrier="IDEAS MMS" mcc="525" mnc="01" apn="e-ideas" user="65IDEAS" password="65ideas" mmsc="http://mms.singtel.com:10021/mmsc" mmsproxy="165.21.42.84" mmsport="8080" type="mms" />
+  <apn carrier="SingTel" mcc="525" mnc="02" apn="e-ideas" type="default,supl" />
+  <apn carrier="SingTel MMS" mcc="525" mnc="02" apn="e-ideas" user="65IDEAS" password="65ideas" mmsc="http://mms.singtel.com:10021/mmsc" mmsproxy="165.21.42.84" mmsport="8080" type="mms" />
+  <apn carrier="M1" mcc="525" mnc="03" apn="sunsurf" user="" password="" type="default,supl" />
+  <apn carrier="M1 MMS" mcc="525" mnc="03" apn="miworld" proxy="" port="" mmsproxy="172.16.14.10" mmsport="8080" mmsc="http://mmsgw:8002" user="65" password="user123" type="mms" />
+  <apn carrier="M1 MMS" mcc="525" mnc="03" apn="Miworld" proxy="172.16.1.23" port="9201" mmsc="http://mmsgw:8002" mmsproxy="172.16.14.10" mmsport="9201" type="mms" />
+  <apn carrier="MiWorld WAP (GPRS)" mcc="525" mnc="03" apn="miworld" user="65" password="user123" proxy="172.16.1.23" port="8081" type="default,supl" />
+  <apn carrier="M1 MMS" mcc="525" mnc="03" apn="miworld" user="65" password="user123" mmsc="http://mmsgw:8002" mmsproxy="172.16.14.10" mmsport="8080" authtype="1" type="mms" />
+  <apn carrier="M1" mcc="525" mnc="03" apn="sunsurf" type="default,supl" />
+  <apn carrier="Sunsurf Internet" mcc="525" mnc="03" apn="sunsurf" type="default,supl" />
+  <apn carrier="StarHub" mcc="525" mnc="05" apn="internet" type="default,supl" />
+  <apn carrier="Gee! MMS" mcc="525" mnc="05" apn="shmms" mmsc="http://mms.starhubgee.com.sg:8002/" mmsproxy="10.12.1.80" mmsport="80" type="mms" />
+  <apn carrier="Gee! (GPRS)" mcc="525" mnc="05" apn="shwap" user="star" password="hub" proxy="10.12.1.2" port="80" type="default,supl" />
+  <apn carrier="StarHub" mcc="525" mnc="05" apn="shwapint" type="default,supl" />
   <apn carrier="B-Mobile MMS" mcc="528" mnc="02" apn="bmobilemms" mmsc="http://mms.bmobile.com.bn/was" mmsproxy="129.9.10.20" mmsport="6500" type="mms" />
   <apn carrier="B-Mobile" mcc="528" mnc="02" apn="bmobilewap" type="default,supl" />
   <apn carrier="DSTCom" mcc="528" mnc="11" apn="dst.internet" user="internet" password="internet" type="default,supl" />
@@ -3335,9 +3151,6 @@
   <apn carrier="Digicel MMS" mcc="539" mnc="88" apn="wap.digicelpacific.com" proxy="" port="" mmsproxy="10.150.122.12" mmsport="8080" mmsc="http://mms.digicelpacific.com:8990" user="" password="" type="mms" />
   <apn carrier="Digicel Web" mcc="541" mnc="05" apn="web.digicelpacific.com" user="" password="" type="default,supl" />
   <apn carrier="Digicel MMS" mcc="541" mnc="05" apn="wap.digicelpacific.com" proxy="" port="" mmsproxy="10.150.122.12" mmsport="8080" mmsc="http://mms.digicelpacific.com:8990" user="" password="" type="mms" />
-  <apn carrier="vodafone fj" mcc="542" mnc="01" apn="live.vodafone.com.fj" proxy="10.202.2.40" port="8080" mmsproxy="10.202.2.40" mmsport="8080" mmsc="http://pxt.vodafone.net.fj/pxtsend" authtype="3" user="" password="" type="*" />
-  <apn carrier="Vodafone FJ MMS" mcc="542" mnc="01" apn="live.vodafone.com.fj" mmsc="http://pxt.vodafone.net.fj/pxtsend" mmsproxy="010.202.002.040" mmsport="9201" type="mms" />
-  <apn carrier="Vodafone FJ" mcc="542" mnc="01" apn="vfinternet.fj" type="default,supl" />
   <apn carrier="Digicel Web" mcc="542" mnc="02" apn="web.digicelpacific.com" user="" password="" type="default,supl" />
   <apn carrier="Digicel MMS" mcc="542" mnc="02" apn="wap.digicelpacific.com" proxy="" port="" mmsproxy="10.150.122.12" mmsport="8080" mmsc="http://mms.digicelpacific.com:8990" user="" password="" type="mms" />
   <apn carrier="Digicel FJ MMS" mcc="542" mnc="02" apn="wap.digicelpacific.com" mmsc="http://mms.digicelpacific.com:8990" mmsproxy="10.150.122.12" mmsport="8080" type="mms" />
@@ -3350,11 +3163,6 @@
   <apn carrier="Digicel MMS" mcc="549" mnc="00" apn="wap.digicelpacific.ws" proxy="" port="" mmsproxy="10.148.122.12" mmsport="8080" mmsc="http://mms.digicelsamoa.net:8990" user="" password="" type="mms" />
   <apn carrier="Mobinil" mcc="602" mnc="01" apn="mobinilweb" authtype="2" type="default,supl" />
   <apn carrier="mobinilmms" apn="mobinilmms" mmsc="http://10.7.13.24:8002/" mmsproxy="62.241.155.45" mmsport="8080" mcc="602" mnc="01" authtype="2" type="mms" />
-  <apn carrier="Vodafone live!" mcc="602" mnc="02" apn="wap.Vodafone.com.eg" user="wap" password="wap" proxy="163.121.178.2" port="8080" authtype="1" type="default,supl" />
-  <apn carrier="Vodafone GPRS Internet" mcc="602" mnc="02" apn="internet.vodafone.net" user="internet" password="internet" authtype="3" type="default,supl" />
-  <apn carrier="Vodafone MMS" mcc="602" mnc="02" apn="mms.vodafone.com.eg" user="mms" password="mms" mmsc="http://mms.vodafone.com.eg/servlets/mms" mmsproxy="163.121.178.2" mmsport="8080" authtype="1" type="mms" />
-  <apn carrier="Vodafone EG" mcc="602" mnc="02" apn="internet.vodafone.net" user="internet" password="internet" type="default,supl" />
-  <apn carrier="Vodafone EG MMS" mcc="602" mnc="02" apn="mms.vodafone.com.eg" user="mms" password="mms" mmsc="http://mms.vodafone.com.eg/servlets/mms" mmsproxy="163.121.178.002" mmsport="8080" type="mms" />
   <apn carrier="Etisalat WAP" apn="etisalat" mmsc="http://10.71.131.7:38090" mmsproxy="10.71.130.29" mmsport="8080" mcc="602" mnc="03" authtype="1" type="*" />
   <apn carrier="Etisalat MMS" apn="etisalat" mmsc="http://10.71.131.7:38090" mmsproxy="10.71.130.29" mmsport="8080" mcc="602" mnc="03" type="mms" />
   <apn carrier="Etisalat internet" mcc="602" mnc="03" apn="Etisalat" mmsc="http://10.71.131.7:38090" mmsproxy="10.71.130.29" mmsport="8080" type="default,supl,mms" />
@@ -3373,7 +3181,7 @@
   <apn carrier="MMS IAM" mcc="604" mnc="01" apn="Mmsiam" proxy="" port="" mmsproxy="10.16.35.50" mmsport="8080" mmsc="http://mms:8002/" user="" password="" type="mms" />
   <apn carrier="Mobile TV" mcc="604" mnc="01" apn="wap.iamgprs.ma" user="" password="" type="default,supl" />
   <apn carrier="IAM" mcc="604" mnc="01" apn="www.iamgprs1.ma" type="default,supl" />
-  <apn carrier="IAM MMS" mcc="604" mnc="01" apn="mmsiam" mmsc="http://mms:8002" mmsproxy="10.16.35.50" mmsport="8080" type="default,supl,mms"/>
+  <apn carrier="IAM MMS" mcc="604" mnc="01" apn="mmsiam" mmsc="http://mms:8002" mmsproxy="10.16.35.50" mmsport="8080" type="default,supl,mms" />
   <apn carrier="weborange" mcc="605" mnc="01" apn="weborange" proxy="10.12.1.52" port="8080" type="default,supl" />
   <apn carrier="MMS Orange" apn="mms.otun" mmsc="https://mms.orange.tn" mmsproxy="10.12.1.52" mmsport="8080" mcc="605" mnc="01" type="mms" />
   <apn carrier="Orange TN" mcc="605" mnc="01" apn="keypro" type="default,supl" />
@@ -3443,8 +3251,6 @@
   <apn carrier="CVMóvel Internet" mcc="625" mnc="01" apn="internet-aac" proxy="" user="" password="" type="default" />
   <apn carrier="Orange GQ MMS" mcc="627" mnc="01" apn="orangemms" user="mms" password="mms" mmsc="http://192.168.17.34/servlets/mms" mmsproxy="192.168.17.2" mmsport="8080" type="mms" />
   <apn carrier="Orange GQ" mcc="627" mnc="01" apn="orangenet" user="net" password="net" type="default,supl" />
-  <apn carrier="Vodacom CD" mcc="630" mnc="01" apn="vodanet" user="vodalive" type="default,supl" />
-  <apn carrier="Vodacom CD" mcc="630" mnc="01" apn="vodanet" proxy="" port="" user="vodalive" password="" mmsc="" type="default,supl" />
   <apn carrier="Unitel Internet" mcc="631" mnc="02" apn="internet.unitel.co.ao" type="default,supl" />
   <apn carrier="Unitel MMS" mcc="631" mnc="02" apn="mms.unitel.co.ao" proxy="" port="" mmsproxy="10.128.2.70" mmsport="8080" mmsc="http://10.128.4.10/wapenc" type="mms" />
   <apn carrier="Movicel Angola" mcc="631" mnc="04" apn="internet.movicel.co.ao" type="default,supl" />
@@ -3469,9 +3275,6 @@
   <apn carrier="Orange KE" mcc="639" mnc="07" apn="bew.orange.co.ke" user="orange" password="orange" type="default,supl" />
   <apn carrier="Orange net KE" mcc="639" mnc="07" apn="wap.orange.co.ke" type="default,supl" />
   <apn carrier="Orange MMS" mcc="639" mnc="07" apn="mms.orange.co.ke" mmsproxy="10.36.16.5" mmsport="8080" mmsc="http://10.36.16.5/servlets/mms" type="mms" />
-  <apn carrier="Vodacom Internet" mcc="640" mnc="04" apn="internet" user="" password="" type="default,supl" />
-  <apn carrier="Vodacom MMS" mcc="640" mnc="04" apn="MMS" proxy="" port="" mmsproxy="10.154.0.8" mmsport="9401" mmsc="http://10.154.0.12/mms/" user="" password="" type="mms" />
-  <apn carrier="Vodacom WAP" mcc="640" mnc="04" apn="wap" proxy="10.154.0.8" port="9401" type="default,supl" />
   <apn carrier="Airtel Tanzania" mcc="640" mnc="05" apn="internet" type="default,supl" />
   <apn carrier="Airtel UG" mcc="641" mnc="01" apn="web.ug.zain.com" type="default,supl" />
   <apn carrier="MTN UG" mcc="641" mnc="10" apn="yellopix.mtn.co.ug" type="default,supl" />
@@ -3521,11 +3324,6 @@
   <apn carrier="Orange BW MMS" mcc="652" mnc="02" apn="mms.orange.co.bw" mmsc="http://10.0.0.242/servlets/mms" mmsproxy="10.0.0.226" mmsport="8080" type="mms" />
   <apn carrier="Orange WAP BW" mcc="652" mnc="02" apn="internet.orange.co.bw" proxy="10.0.0.226" port="8080" type="default,supl" />
   <apn carrier="MTN" mcc="653" mnc="10" apn="mymtn.co.sz" proxy="" port="" user="" password="" mmsc="" authtype="1" type="default,supl" />
-  <apn carrier="Vlive!" mcc="655" mnc="01" apn="internet" proxy="196.6.128.12" port="8080" mmsc="" user="" password="" authtype="3" type="default,supl" />
-  <apn carrier="Vlive!MMS" mcc="655" mnc="01" apn="mms.vodacom.net" proxy="" port="" mmsproxy="196.6.128.13" mmsport="8080" mmsc="http://mmsc.vodacom4me.co.za" user="" password="" authtype="3" type="mms" />
-  <apn carrier="Vodacom ZA" mcc="655" mnc="01" apn="internet" type="default,supl" />
-  <apn carrier="Vodacom ZA MMS" mcc="655" mnc="01" apn="mms.vodacom.net" mmsc="http://mmsc.vodacom4me.co.za/" mmsproxy="196.6.128.13" mmsport="8080" type="mms" />
-  <apn carrier="LTE.Vodacom" mcc="655" mnc="01" apn="lte.vodacom.za" type="default,supl" />
   <apn carrier="TelkomSA internet" mcc="655" mnc="02" apn="internet" type="default,supl" />
   <apn carrier="TelkomSA mms" mcc="655" mnc="02" apn="mms" mmsc="http://mms.8ta.com:38090/was" mmsproxy="41.151.254.162" mmsport="8080" type="mms" />
   <apn carrier="CELL C INTERNET" mcc="655" mnc="07" apn="internet" proxy="" port="8080" mmsproxy="196.31.116.250" mmsport="8080" mmsc="http://mms.cmobile.co.za" type="*" />
@@ -3592,7 +3390,7 @@
   <apn carrier="+movil MMS" mcc="714" mnc="010" apn="apn02.cwpanama.com.pa" proxy="" port="" mmsproxy="172.25.3.5" mmsport="8080" mmsc="http://mms.zonamovil.com.pa" user="" password="" type="mms" />
   <apn carrier="Movistar INTERNET" mcc="714" mnc="02" apn="internet.movistar.pa" user="movistarpa" password="movistarpa" type="default,supl" />
   <apn carrier="Movistar MMS" mcc="714" mnc="02" apn="mms.movistar.pa" proxy="" port="" mmsproxy="10.12.21.1" mmsport="80" mmsc="http://mms.movistar.pa/" user="movistarpamms" password="movistarpa" type="mms" />
-  <apn carrier="Movistar PA" mcc="714" mnc="02" apn="internet.movistar.pa" user="movistarpa" password="movistarpa" type="default,supl"/>
+  <apn carrier="Movistar PA" mcc="714" mnc="02" apn="internet.movistar.pa" user="movistarpa" password="movistarpa" type="default,supl" />
   <apn carrier="Movistar INTERNET" mcc="714" mnc="020" apn="internet.movistar.pa" user="movistarpa" password="movistarpa" type="default,supl" />
   <apn carrier="Movistar MMS" mcc="714" mnc="020" apn="mms.movistar.pa" proxy="" port="" mmsproxy="10.12.21.1" mmsport="80" mmsc="http://mms.movistar.pa/" user="movistarpamms" password="movistarpa" type="mms" />
   <apn carrier="PA WAP CLARO" mcc="714" mnc="03" apn="wap.claro.com.pa" proxy="10.240.3.1" port="8799" mmsc="" user="CLAROWAP" password="CLAROWAP" type="default,supl" />
@@ -3608,8 +3406,6 @@
   <apn carrier="Movistar MMS" mcc="714" mnc="20" apn="mms.movistar.pa" proxy="" port="" mmsproxy="10.12.21.1" mmsport="80" mmsc="http://mms.movistar.pa/" user="movistarpamms" password="movistarpa" type="mms" />
   <apn carrier="Movistar INTERNET" mcc="716" mnc="06" apn="movistar.pe" user="movistar@datos" password="movistar" authtype="1" type="default,supl" />
   <apn carrier="Movistar MMS" mcc="716" mnc="06" apn="mms.movistar.pe" proxy="" port="" mmsproxy="200.4.196.118" mmsport="8080" mmsc="http://mmsc.telefonicamovistar.com.pe:8088/mms/" user="movistar@mms" password="movistar" authtype="1" type="mms" />
-  <apn carrier="CLARO DATOS" mcc="716" mnc="10" apn="claro.pe" user="claro" password="claro" authtype="1" type="default,supl" />
-  <apn carrier="Claro MMS" mcc="716" mnc="10" apn="mms.claro.pe" proxy="" port="" mmsproxy="192.168.231.30" mmsport="80" mmsc="http://claro/servlets/mms" user="claro" password="claro" authtype="1" type="mms" />
   <apn carrier="Entel Internet" mcc="716" mnc="17" apn="entel.pe" user="" password="" authtype="0" type="default,supl" />
   <apn carrier="Entel MMS" mcc="716" mnc="17" apn="mms.entel.pe" proxy="" port="" mmsc="http://mms.nextel.pe" user="" password="" authtype="0" type="mms" />
   <apn carrier="Movistar AG" mcc="722" mnc="007" apn="internet.unifon" user="wap" password="password" type="default,supl" />
@@ -3820,4 +3616,244 @@
   <apn carrier="Claro MMS" mcc="748" mnc="10" apn="mms.ctimovil.com.uy" proxy="" port="" mmsc="http://mms.ctimovil.com.uy" user="" password="" type="mms" />
   <apn carrier="Claro UY" mcc="748" mnc="10" apn="gprs.claro.com.uy" user="ctigpr" password="ctigpr999" type="default,supl" />
   <apn carrier="Claro UY MMS" mcc="748" mnc="10" apn="mms.ctimovil.com.uy" user="ctimms" password="ctimms999" mmsc="http://mms.ctimovil.com.uy" mmsproxy="170.051.255.240" mmsport="9201" type="mms" />
+  <apn carrier="Bouygues Telecom" mcc="208" mnc="20" apn="mmsbouygtel.com" mmsc="http://mms.bouyguestelecom.fr/mms/wapenc" type="default,mms,xcap" authtype="1" protocol="IPV6" roaming_protocol="IP" />
+  <apn carrier="Bouygues IMS" mcc="208" mnc="20" apn="ims" authtype="1" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone Internet" mcc="216" mnc="70" apn="internet.vodafone.net" type="default,supl,dun" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Vodafone MMS" mcc="216" mnc="70" apn="mms.vodafone.net" mmsc="http://mms.vodafone.hu/servlets/mms" mmsport="8080" mmsproxy="80.244.97.2" type="mms" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Accesso a Internet da cellulare" mcc="222" mnc="10" apn="mobile.vodafone.it" type="default,supl" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="MMS Vodafone" mcc="222" mnc="10" apn="mms.vodafone.it" mmsc="http://mms.vodafone.it/servlets/mms" mmsport="80" mmsproxy="10.128.224.10" type="mms" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Tethering Internet" mcc="222" mnc="10" apn="web.omnitel.it" type="dun" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="IMS" mcc="222" mnc="10" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Accesso Internet da Cellulare" mcc="222" mnc="10" apn="web.ho-mobile.it" type="default,supl" protocol="IP" roaming_protocol="IP" mvno_type="gid" mvno_match_data="20" />
+  <apn carrier="Tethering Internet" mcc="222" mnc="10" apn="internet.ho-mobile.it" type="dun" protocol="IP" roaming_protocol="IP" mvno_type="gid" mvno_match_data="20" />
+  <apn carrier="Vodafone live!" mcc="226" mnc="01" apn="live.vodafone.com" type="default,supl,dun" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Vodafone MMS" mcc="226" mnc="01" apn="mms.vodafone.ro" mmsc="http://multimedia/servlets/mms" mmsport="8080" mmsproxy="193.230.161.231" password="vodafone" type="mms" user="mms" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="ims" mcc="226" mnc="01" apn="ims" type="ims" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Digi.Mobil" mcc="226" mnc="05" apn="internet" type="default,supl" />
+  <apn carrier="MMS" mcc="226" mnc="05" apn="mms" mmsc="http://10.10.3.133:8002" mmsport="8080" mmsproxy="10.10.3.130" type="mms" />
+  <apn carrier="IMS" mcc="226" mnc="05" apn="ims" type="ims" protocol="IP" roaming_protocol="IPV4V6" />
+  <apn carrier="Pay Monthly Data" mcc="234" mnc="15" apn="wap.vodafone.co.uk" user="wap" password="wap" mmsc="http://mms.vodafone.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" authtype="1" type="default,supl,mms" protocol="IPV4V6" roaming_protocol="IPV4V6" read_only="true" />
+  <apn carrier="Pay as You Go/VOXI Data" mcc="234" mnc="15" apn="pp.vodafone.co.uk" user="wap" password="wap" mmsc="http://mms.vodafone.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" authtype="1" type="default,supl,mms" protocol="IPV4V6" roaming_protocol="IPV4V6" read_only="true" />
+  <apn carrier="Vodafone UK IMS" mcc="234" mnc="15" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Talkmob PAYG Int" mcc="234" mnc="15" apn="payg.talkmobile.co.uk" type="default,supl" mvno_match_data="C1" mvno_type="gid" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Talkmob PAYG MMS" mcc="234" mnc="15" apn="payg.talkmobile.co.uk" user="wap" password="wap" mmsc="http://mms.talkmobile.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" authtype="1" type="mms" mvno_match_data="C1" mvno_type="gid" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Talkmob Internet" mcc="234" mnc="15" apn="talkmobile.co.uk" type="default,supl" mvno_match_data="C1" mvno_type="gid" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Talkmob MMS" mcc="234" mnc="15" apn="talkmobile.co.uk" user="wap" password="wap" mmsc="http://mms.talkmobile.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" authtype="1" type="mms" mvno_match_data="C1" mvno_type="gid" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="TalkTalk WAP" mcc="234" mnc="15" apn="mobile.talktalk.co.uk" mmsc="http://mms.talktalk.co.uk/servlets/mms" mmsproxy="212.183.137.12" mmsport="8799" type="default,supl,mms" mvno_match_data="70" mvno_type="gid" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Tele2 Data" mcc="240" mnc="07" apn="4g.tele2.se" mmsc="http://mmsc.tele2.se/" mmsport="8080" mmsproxy="mmsproxy.tele2.se" type="default,supl,mms" protocol="IPV4V6" roaming_protocol="IP" />
+  <apn carrier="MTS Internet" mcc="250" mnc="01" apn="internet.mts.ru" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="MTS MMS" mcc="250" mnc="01" apn="mms.mts.ru" mmsc="http://mmsc" mmsport="8080" mmsproxy="192.168.192.192" type="mms" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="MTS IMS" mcc="250" mnc="01" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Megafon Internet" mcc="250" mnc="02" apn="internet" authtype="1" password="gdata" type="default,supl" user="gdata" />
+  <apn carrier="Megafon MMS" mcc="250" mnc="02" apn="mms" authtype="1" mmsc="http://mmsc:8002" mmsport="8080" mmsproxy="10.10.10.10" password="mms" type="mms" user="mms" />
+  <apn carrier="Megafon IMS" mcc="250" mnc="02" apn="ims" type="ims" protocol="IPV4V6" />
+  <apn carrier="NCC" apn="mms" mcc="250" mnc="03" mmsproxy="10.0.3.20" mmsport="8080" mmsc="http://10.0.3.50" type="mms" />
+  <apn carrier="МТС-интернет" apn="internet.mts.ru" mcc="250" mnc="04" user="mts" password="mts" type="default,supl" />
+  <apn carrier="МТС Центр MMS" apn="mms.mts.ru" mcc="250" mnc="04" user="mts" password="mts" mmsproxy="192.168.192.192" mmsport="8080" mmsc="http://mmsc" type="mms" />
+  <apn carrier="ETK" apn="internet.etk.ru" mcc="250" mnc="05" type="default,supl,mms" />
+  <apn carrier="МТС-интернет" apn="internet.mts.ru" mcc="250" mnc="05" user="mts" password="mts" type="default,supl" />
+  <apn carrier="МТС Центр MMS" apn="mms.mts.ru" mcc="250" mnc="05" user="mts" password="mts" mmsproxy="192.168.192.192" mmsport="8080" mmsc="http://mmsc" type="mms" />
+  <apn carrier="Sberbank-Telecom Internet" mcc="250" mnc="050" apn="internet.sberbank-tele.com" user="" password="" type="default,supl" />
+  <apn carrier="Sberbank-Telecom MMS" mcc="250" mnc="050" apn="mms.sberbank-tele.com" user="" password="" mmsc="http://mmsc" mmsproxy="10.77.36.100" mmsport="8080" type="mms" />
+  <apn carrier="Sberbank-Telecom IMS" mcc="250" mnc="050" apn="ims.sberbank-tele.com" type="ims" protocol="IPV4V6" />
+  <apn carrier="МТС-интернет" apn="internet.mts.ru" mcc="250" mnc="10" user="mts" password="mts" type="default,supl" />
+  <apn carrier="МТС Центр MMS" apn="mms.mts.ru" mcc="250" mnc="10" user="mts" password="mts" mmsproxy="192.168.192.192" mmsport="8080" mmsc="http://mmsc" type="mms" />
+  <apn carrier="yota" mcc="250" mnc="11" apn="internet.yota" type="default,supl" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="MMS.Yota" mcc="250" mnc="11" apn="mms.yota" type="mms" protocol="IP" roaming_protocol="IP" proxy="10.10.10.10" port="8080" mmsc="http://mmsc:8002" />
+  <apn carrier="Baykalwestcom" mcc="250" mnc="12" apn="inet.bwc.ru" authtype="1" password="bwc" type="default,supl" user="bwc" />
+  <apn carrier="МТС-интернет" apn="internet.mts.ru" mcc="250" mnc="13" user="mts" password="mts" type="default,supl" />
+  <apn carrier="МТС Центр MMS" apn="mms.mts.ru" mcc="250" mnc="13" user="mts" password="mts" mmsproxy="192.168.192.192" mmsport="8080" mmsc="http://mmsc" type="mms" />
+  <apn carrier="MMS" apn="mms.ntc" mcc="250" mnc="16" mmsproxy="80.243.64.68" mmsport="8080" mmsc="http://mmsc.vntc.ru/was" type="mms" />
+  <apn carrier="Internet" apn="internet.usi.ru" mcc="250" mnc="17" type="default,supl" />
+  <apn carrier="MMS" apn="mms.usi.ru" mcc="250" mnc="17" mmsproxy="192.168.168.192" mmsport="8080" mmsc="http://mms" type="mms" />
+  <apn carrier="Motiv" mcc="250" mnc="35" apn="inet.ycc.ru" authtype="1" type="default,supl" user="motiv" />
+  <apn carrier="Tele2 Internet" mcc="250" mnc="20" apn="internet.tele2.ru" type="default" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Tele2 MMS" mcc="250" mnc="20" apn="mms.tele2.ru" mmsc="http://mmsc.tele2.ru" mmsport="8080" mmsproxy="193.12.40.65" type="mms" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Tele2 IMS" mcc="250" mnc="20" apn="ims.tele2.ru" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Letai MMS" mcc="250" mnc="27" apn="mms" mmsc="https://mmsc:8002" mmsproxy="mmsc" mmsport="8080" type="mms" />
+  <apn carrier="Letai Internet" mcc="250" mnc="27" apn="internet.letai.ru" type="default" />
+  <apn carrier="Megafon internet" mcc="250" mnc="30" apn="internet" user="" password="" type="default" />
+  <apn carrier="IMS" mcc="250" mnc="30" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="WIN Internet" mcc="250" mnc="32" apn="internet" type="default" authtype="1" user="internet" password="internet" />
+  <apn carrier="internet" mcc="250" mnc="33" apn="internet.sts.ru" type="default" />
+  <apn carrier="KTK" mcc="250" mnc="34" apn="internet.ktkru.ru" type="default" />
+  <apn carrier="MOTIV Internet" mcc="250" mnc="35" apn="inet.ycc.ru" type="default,supl" authtype="2" user="motiv" password="motiv" />
+  <apn carrier="MOTIV MMS" mcc="250" mnc="35" apn="mms.ycc.ru" type="mms" authtype="2" mmsc="http://mms.ycc.ru" mmsproxy="172.16.2.10" mmsport="8080" />
+  <apn carrier="МТС-интернет" apn="internet.mts.ru" mcc="250" mnc="39" user="mts" password="mts" type="default,supl" />
+  <apn carrier="МТС Центр MMS" apn="mms.mts.ru" mcc="250" mnc="39" user="mts" password="mts" mmsproxy="192.168.192.192" mmsport="8080" mmsc="http://mmsc" type="mms" />
+  <apn carrier="AIVA" mcc="250" mnc="42" apn="internet" authtype="1" type="default" />
+  <apn carrier="Sberbank-Telecom Internet" mcc="250" mnc="50" apn="internet.sberbank-tele.com" type="default,supl" />
+  <apn carrier="Sberbank-Telecom MMS" mcc="250" mnc="50" apn="mms.sberbank-tele.com" mmsc="http://mmsc" mmsproxy="10.77.36.100" mmsport="8080" type="mms" />
+  <apn carrier="Letai MMS" mcc="250" mnc="54" apn="mms" mmsc="https://mmsc:8002" mmsproxy="mmsc" mmsport="8080" type="mms" />
+  <apn carrier="Letai Internet" mcc="250" mnc="54" apn="internet.letai.ru" type="default" />
+  <apn carrier="WIFIRE Internet" mcc="250" mnc="59" apn="internet.nbn" type="default" />
+  <apn carrier="internet" mcc="250" mnc="60" apn="internet" type="default" user="internet" password="internet" />
+  <apn carrier="МТС-интернет" apn="internet.mts.ru" mcc="250" mnc="92" user="mts" password="mts" type="default,supl" />
+  <apn carrier="МТС Центр MMS" apn="mms.mts.ru" mcc="250" mnc="92" user="mts" password="mts" mmsproxy="192.168.192.192" mmsport="8080" mmsc="http://mmsc" type="mms" />
+  <apn carrier="Beeline Internet" mcc="250" mnc="99" apn="internet.beeline.ru" authtype="1" password="beeline" type="default,supl" user="beeline" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Beeline MMS" mcc="250" mnc="99" apn="mms.beeline.ru" authtype="1" mmsc="http://mms/" mmsport="8080" mmsproxy="192.168.94.23" password="beeline" type="mms" user="beeline" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="IMS" mcc="250" mnc="99" apn="IMS" type="ims" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Tinkoff Mobile" apn="m.tinkoff" mcc="250" mnc="62" type="default,supl,dun" />
+  <apn carrier="MTS-internet" mcc="255" mnc="01" apn="internet" type="default,supl" />
+  <apn carrier="Vodafone MMS" mcc="255" mnc="01" apn="mms" mmsc="http://mms/" mmsport="8080" mmsproxy="192.168.10.10" type="mms" />
+  <apn carrier="Vodafone DE" apn="web.vodafone.de" mcc="262" mnc="04" type="default,supl" />
+  <apn carrier="Vodafone DE-MMS" apn="event.vodafone.de" mcc="262" mnc="04" mmsproxy="139.7.29.17" mmsport="80" mmsc="http://139.7.24.1/servlets/mms" type="mms" />
+  <apn carrier="Vodafone DE" apn="web.vodafone.de" mcc="262" mnc="09" type="default,supl" />
+  <apn carrier="Vodafone DE-MMS" apn="event.vodafone.de" mcc="262" mnc="09" mmsproxy="139.7.29.17" mmsport="80" mmsc="http://139.7.24.1/servlets/mms" type="mms" />
+  <apn carrier="Vodafone Net2" mcc="268" mnc="01" apn="net2.vodafone.pt" user="vodafone" password="vodafone" authtype="1" type="default,supl,mms" protocol="IPV4V6" roaming_protocol="IPV4V6" read_only="true" />
+  <apn carrier="Vodafone MMS" mcc="268" mnc="01" apn="net2.vodafone.pt" mmsproxy="iproxy.vodafone.pt" mmsc="http://mms.vodafone.pt/servlets/mms" mmsport="80" authtype="1" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" read_only="true" />
+  <apn carrier="Vodafone Internet" mcc="268" mnc="01" apn="internet.vodafone.pt" authtype="1" type="dun" protocol="IPV4V6" roaming_protocol="IPV4V6" read_only="true" />
+  <apn carrier="IMS" mcc="268" mnc="01" apn="ims" type="ims" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Vodafone Net2" mcc="268" mnc="89" apn="net2.vodafone.pt" mmsc="http://mms.vodafone.pt/servlets/mms" mmsproxy="iproxy.vodafone.pt" mmsport="80" type="default,supl,xcap,mms" />
+  <apn carrier="Vodafone IMS" mcc="268" mnc="89" apn="ims" authtype="1" type="ims" />
+  <apn carrier="Internet vodafone" mcc="268" mnc="89" apn="internet.vodafone.pt" user="vodafone" password="vodafone" authtype="1" type="dun" />
+  <apn carrier="Internet" mcc="272" mnc="01" apn="hs.vodafone.ie" type="default,supl" protocol="IP" roaming_protocol="IP" read_only="true" />
+  <apn carrier="Vodafone live!" mcc="272" mnc="01" apn="live.vodafone.com" type="default,supl" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Vodafone MMS" mcc="272" mnc="01" apn="mms.vodafone.net" mmsc="http://www.vodafone.ie/mms" mmsport="80" mmsproxy="10.24.59.200" type="mms" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Vodafone Internet" mcc="274" mnc="02" apn="gprs.is" type="default,supl" />
+  <apn carrier="Vodafone Live" mcc="274" mnc="02" apn="live.gprs.is" proxy="10.22.0.22" port="8080" type="default,supl" authtype="0" />
+  <apn carrier="Vodafone MMS" mcc="274" mnc="02" apn="mms.gprs.is" mmsc="http://mmsc.vodafone.is" mmsport="8080" mmsproxy="10.22.0.10" type="mms" />
+  <apn carrier="Vodafone Internet" mcc="274" mnc="03" apn="gprs.is" authtype="0" type="default,supl,fota,dun" />
+  <apn carrier="Vodafone MMS" mcc="274" mnc="03" apn="mms.gprs.is" authtype="0" mmsc="http://mmsc.vodafone.is" mmsproxy="10.22.0.10" mmsport="8080" type="mms" />
+  <apn carrier="Vodafone MT" mcc="278" mnc="01" apn="internet" password="internet" type="default,supl" user="internet" />
+  <apn carrier="Vodafone MT-MMS" mcc="278" mnc="01" apn="mms.vodafone.com.mt" mmsc="http://mms.vodafone.com.mt/servlets/mms" mmsport="8080" mmsproxy="10.12.0.3" type="mms" />
+  <apn carrier="TURKCELL INTERNET" mcc="286" mnc="01" apn="internet" type="default,supl" />
+  <apn carrier="TURKCELL MMS" mcc="286" mnc="01" apn="mms" authtype="1" mmsc="http://mms.turkcell.com.tr/servlets/mms" mmsport="8080" mmsproxy="212.252.169.217" password="mms" type="mms" user="mms" />
+  <apn carrier="Turkcell VoLTE" mcc="286" mnc="01" apn="IMS" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone internet" mcc="286" mnc="02" apn="internet" authtype="1" type="default,supl" />
+  <apn carrier="Vodafone MMS" mcc="286" mnc="02" apn="mms" authtype="1" mmsc="http://217.31.233.18:6001/MM1Servlet" mmsport="9401" mmsproxy="217.31.233.18" password="vodafone" type="mms" user="vodafone" />
+  <apn carrier="IMS" mcc="286" mnc="02" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="FO - Vodafone Web" mcc="288" mnc="02" apn="vmc.vodafone.fo" type="default,supl" authtype="1" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="01" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="01" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="01" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="05" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="05" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="05" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="11" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="11" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="11" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="13" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="13" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="13" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="15" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="15" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="15" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="20" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="20" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="20" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone Connect" mcc="404" mnc="206" apn="www" type="default,supl" />
+  <apn carrier="VodafoneLive!" mcc="404" mnc="206" apn="portalnmms" proxy="10.10.1.100" port="9401" mmsc="http://mms1.live.vodafone.in/mms/" mmsproxy="10.10.1.100" type="mms" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="27" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="27" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="27" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="30" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="30" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="30" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Airtel MMS" mcc="404" mnc="31" apn="airtelmms.com" authtype="1" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Mobile Office" mcc="404" mnc="31" apn="airtelgprs.com" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="IMS" mcc="404" mnc="31" apn="ims" type="ims" protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="43" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="43" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="43" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Mobile Office" mcc="404" mnc="45" apn="airtelgprs.com" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Airtel MMS" mcc="404" mnc="45" apn="airtelmms.com" authtype="1" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="IMS" mcc="404" mnc="45" apn="ims" type="ims" protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="46" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="46" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="46" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Airtel MMS" mcc="404" mnc="49" apn="airtelmms.com" authtype="1" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Mobile Office" mcc="404" mnc="49" apn="airtelgprs.com" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="IMS" mcc="404" mnc="49" apn="ims" type="ims" protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="60" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="60" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="60" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="84" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="84" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="84" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="86" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="86" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="86" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="404" mnc="88" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="404" mnc="88" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="404" mnc="88" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Mobile Office" mcc="404" mnc="98" apn="airtelgprs.com" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Airtel MMS" mcc="404" mnc="98" apn="airtelmms.com" authtype="1" mmsc="http://100.1.201.171:10021/mmsc" mmsproxy="100.1.201.172" mmsport="8799" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="IMS" mcc="404" mnc="98" apn="ims" type="ims" protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="405" mnc="66" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="405" mnc="66" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="405" mnc="66" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="405" mnc="67" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="405" mnc="67" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="405" mnc="67" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="405" mnc="750" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="405" mnc="750" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="405" mnc="750" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="405" mnc="751" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="405" mnc="751" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="405" mnc="751" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="405" mnc="752" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="405" mnc="752" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="405" mnc="752" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="405" mnc="753" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="405" mnc="753" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="405" mnc="753" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="405" mnc="754" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="405" mnc="754" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="405" mnc="754" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="405" mnc="755" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="405" mnc="755" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="405" mnc="755" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafonemobileconnect" mcc="405" mnc="756" apn="www" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="405" mnc="756" apn="portalnmms" mmsc="http://mms1.live.vodafone.in/mms/" mmsport="9401" mmsproxy="10.10.1.100" type="mms" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="405" mnc="756" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Internet" apn="jionet" mcc="405" mnc="857" type="default" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="ims" apn="ims" mcc="405" mnc="857" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone MMS" mcc="427" mnc="02" apn="vodafone.com.qa" mmsc="http://mms.vodafone.com.qa/mmsc" mmsport="80" mmsproxy="10.101.97.102" type="mms" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="Vodafone Qatar" mcc="427" mnc="02" apn="web.vodafone.com.qa" type="default" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="IMS" mcc="427" mnc="02" apn="ims" type="ims" protocol="IP" roaming_protocol="IP" />
+  <apn carrier="中国移动 (China Mobile) GPRS" mcc="460" mnc="00" apn="cmnet" type="default,supl" />
+  <apn carrier="中国移动 (China Mobile) WAP" mcc="460" mnc="00" apn="cmwap" port="80" proxy="10.0.0.172" type="default,supl" />
+  <apn carrier="中国移动彩信 (China Mobile)" mcc="460" mnc="00" apn="cmwap" mmsc="http://mmsc.monternet.com" mmsport="80" mmsproxy="10.0.0.172" port="80" proxy="10.0.0.172" type="mms" />
+  <apn carrier="中国移动 (China Mobile) IMS" mcc="460" mnc="00" apn="ims" type="ims" protocol="IPV4V6" />
+  <apn carrier="沃宽带用户连接互联网" mcc="460" mnc="01" apn="3gnet" type="default,supl,xcap" read_only="true" />
+  <apn carrier="沃宽带用户手机上网" mcc="460" mnc="01" apn="3gwap" proxy="10.0.0.172" port="80" type="default,supl" read_only="true" />
+  <apn carrier="联通彩信" mcc="460" mnc="01" apn="3gwap" proxy="10.0.0.172" port="80" mmsproxy="10.0.0.172" mmsport="80" mmsc="http://mmsc.myuni.com.cn" type="mms" read_only="true" />
+  <apn carrier="联通IMS" mcc="460" mnc="01" apn="ims" type="ims" protocol="IPV4V6" read_only="true" />
+  <apn carrier="CTNET" mcc="460" mnc="01" apn="ctnet" type="default,dun,xcap" authtype="3" user="ctnet@mycdma.cn" password="vnet.mobi" mvno_type="spn" mvno_match_data="China Telecom" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="IMS" mcc="460" mnc="01" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" mvno_type="spn" mvno_match_data="China Telecom" />
+  <apn carrier="中国移动 (China Mobile) GPRS" mcc="460" mnc="02" apn="cmnet" type="default,supl" />
+  <apn carrier="中国移动 (China Mobile) WAP" mcc="460" mnc="02" apn="cmwap" port="80" proxy="10.0.0.172" type="default,supl" />
+  <apn carrier="中国移动彩信 (China Mobile)" mcc="460" mnc="02" apn="cmwap" mmsc="http://mmsc.monternet.com" mmsport="80" mmsproxy="10.0.0.172" port="80" proxy="10.0.0.172" type="mms" />
+  <apn carrier="中国移动 (China Mobile) IMS" mcc="460" mnc="02" apn="ims" type="ims" protocol="IPV4V6" />
+  <apn carrier="中国电信 (China Telecom) GPRS" mcc="460" mnc="11" apn="ctnet" authtype="3" password="vnet.mobi" type="default,hipri,internet,supl" user="ctnet@mycdma.cn" />
+  <apn carrier="IMS" mcc="460" mnc="11" apn="ims" type="ims" protocol="IPV4V6" read_only="true" />
+  <apn carrier="中国电信彩信 (China Telecom)" mcc="460" mnc="11" apn="ctwap" authtype="3" mmsc="http://mmsc.vnet.mobi" mmsport="80" mmsprotocol="2.0" mmsproxy="10.0.0.200" password="vnet.mobi" type="mms" user="ctwap@mycdma.cn" />
+  <apn carrier="Vodafone live!" mcc="505" mnc="03" apn="live.vodafone.com" mmsc="http://pxt.vodafone.net.au/pxtsend" mmsport="8080" mmsproxy="10.202.2.60" type="default,supl,mms" />
+  <apn carrier="IMS" mcc="505" mnc="03" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone Live!" mcc="505" mnc="99" apn="live.vodafone.com" mmsc="http://pxt.vodafone.net.au/pxtsend" mmsproxy="10.202.2.60" mmsport="8080" />
+  <apn carrier="Smartfren4G" mcc="510" mnc="09" apn="Smartfren4G" user="smartfren" password="smartfren" authtype="3" type="default,supl,xcap" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="IMS" mcc="510" mnc="09" apn="ims" authtype="3" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Telkomsel GPRS WEB" mcc="510" mnc="10" apn="internet" password="wap123" type="default,supl" user="wap" />
+  <apn carrier="TSEL MMS" mcc="510" mnc="10" apn="mms" mmsc="http://mms.telkomsel.com" mmsport="8000" mmsproxy="10.1.89.150" password="wap123" type="mms" user="wap" />
+  <apn carrier="Telkomsel IMS" mcc="510" mnc="10" apn="ims" authtype="3" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" />
+  <apn carrier="Vodafone" mcc="542" mnc="01" apn="default" type="default,supl" />
+  <apn carrier="Vodafone internet" mcc="602" mnc="02" apn="internet.vodafone.net" authtype="3" password="internet" type="default,supl" user="internet" />
+  <apn carrier="Vodafone MMS" mcc="602" mnc="02" apn="mms.vodafone.com.eg" authtype="1" mmsc="http://mms.vodafone.com.eg/servlets/mms" mmsport="8080" mmsproxy="163.121.178.2" password="mms" type="mms" user="mms" />
+  <apn carrier="Vodafone WAP" mcc="602" mnc="02" apn="wap.vodafone.com.eg" authtype="3" password="wap" port="8080" proxy="163.121.178.2" type="default,supl" user="wap" />
+  <apn carrier="Vodacom Internet CD" mcc="630" mnc="01" apn="vodanet" port="8080" type="default" />
+  <apn carrier="Vodacom MMS" mcc="630" mnc="01" apn="vodalive" type="mms" authtype="0" mmsproxy="172.24.97.1" mmsc="http://172.24.97.1/mmsc" mmsport="8080" />
+  <apn carrier="Vodacom INTERNET" mcc="640" mnc="04" apn="internet" type="default,supl" authtype="2" />
+  <apn carrier="Vodacom MMS" mcc="640" mnc="04" apn="MMS" mmsproxy="10.154.0.8" mmsport="9401" mmsc="http://10.154.0.12/mms/" type="mms" />
+  <apn carrier="Vodacom" mcc="643" mnc="04" apn="internet" />
+  <apn carrier="MMS.Vodacom" mcc="655" mnc="01" apn="mms.vodacom.net" mmsc="http://mmsc.vodacom4me.co.za" mmsport="8080" mmsproxy="196.6.128.13" protocol="IP" type="mms" />
+  <apn carrier="MMS.Vodacom" mcc="655" mnc="01" apn="lte.vodacom.za" mmsc="http://mmsc.vodacom4me.co.za" mmsport="8080" mmsproxy="196.6.128.13" type="mms" bearer="14" />
+  <apn carrier="Smart.Vodacom" mcc="655" mnc="01" apn="internet" protocol="IP" type="default" />
+  <apn carrier="Internet.Vodacom" mcc="655" mnc="01" apn="wap" port="8080" proxy="196.6.128.12" protocol="IP" type="default" />
+  <apn carrier="LTE.Vodacom" mcc="655" mnc="01" apn="lte.vodacom.za" type="default,supl" protocol="IP" bearer="14" />
+  <apn carrier="ims" mcc="655" mnc="01" apn="ims" type="ims" protocol="IP" />
+  <apn carrier="IMS.Vodacom" mcc="655" mnc="01" apn="ims" type="ims" protocol="IPV4V6" />
+  <apn carrier="CLARO DATOS" mcc="716" mnc="10" apn="claro.pe" user="claro" password="claro" authtype="1" type="default,supl" protocol="IPV4V6" roaming_protocol="IPV4V6" read_only="true" />
+  <apn carrier="CLARO MMS" mcc="716" mnc="10" apn="mms.claro.pe" authtype="1" mmsc="http://claro/servlets/mms" mmsport="80" mmsproxy="192.168.231.30" type="mms" password="claro" user="claro" protocol="IPV4V6" roaming_protocol="IPV4V6" read_only="true" />
+  <apn carrier="Ims" mcc="716" mnc="10" apn="ims" type="ims" protocol="IPV4V6" roaming_protocol="IPV4V6" read_only="true" />
 </apns>


### PR DESCRIPTION
- This config file is a combination of the existing apns-conf and
  several APNs updated from MIUI's apns-conf.xml.
- This fixes IMS on various carriers.
- The following MCC MNCs were updated:
        208 20
        216 70
        222 10
        226 01
        226 05
        234 15
        240 07
        250 01
        250 02
        250 03
        250 04
        250 05
        250 06
        250 08
        250 09
        250 10
        250 11
        250 12
        250 13
        250 14
        250 16
        250 17
        250 18
        250 20
        250 23
        250 27
        250 30
        250 32
        250 33
        250 34
        250 35
        250 37
        250 39
        250 40
        250 42
        250 43
        250 50
        250 54
        250 55
        250 59
        250 60
        250 62
        250 77
        250 92
        250 99
        255 01
        262 04
        262 09
        268 01
        268 89
        272 01
        274 02
        274 03
        278 01
        286 01
        286 02
        288 02
        404 01
        404 05
        404 11
        404 13
        404 15
        404 20
        404 206
        404 27
        404 30
        404 31
        404 43
        404 45
        404 46
        404 49
        404 60
        404 84
        404 86
        404 88
        404 98
        405 66
        405 67
        405 750
        405 751
        405 752
        405 753
        405 754
        405 755
        405 756
        405 857
        427 02
        460 00
        460 01
        460 02
        460 11
        505 03
        505 99
        510 09
        510 10
        542 01
        602 02
        630 01
        640 04
        643 04
        655 01
        716 10

Signed-off-by: ZIDAN44 <zidan44@pixelexperience.org>
Change-Id: Ic71377f7b02f42f8d5c88b1a0149596bcbe814a9